### PR TITLE
feat: color select icon and hide colors when not selected on bar chart

### DIFF
--- a/frontend/src/metadata/cells/MetadataCell.svelte
+++ b/frontend/src/metadata/cells/MetadataCell.svelte
@@ -225,7 +225,7 @@
 	on:mouseenter={() => (hoveringCell = true)}
 	on:mouseleave={() => (hoveringCell = false)}>
 	<div id="info">
-		<div id="label">
+		<div id="label" class="top-text">
 			<span style:color={selectedHashColor}>{col.name}</span>
 		</div>
 
@@ -266,20 +266,26 @@
 					</div>
 				</div>
 			{/if}
+
 			{#if selection && selection[0] === "range"}
-				<span>
-					{selection ? selection[1].toFixed(2) + " - " : ""}
-					{selection ? selection[2].toFixed(2) : ""}
-				</span>
+				<div class="top-text">
+					<span>
+						{selection ? selection[1].toFixed(2) + " - " : ""}
+						{selection ? selection[2].toFixed(2) : ""}
+					</span>
+				</div>
 			{/if}
+
 			{#if chartType !== ChartType.Other && shouldColor && (hoveringCell || selectedHash)}
-				<IconButton
-					size="button"
-					class="material-icons"
-					style="color: {selectedHashColor}; height: 100%; font-size: 18px;"
-					on:click={() => {
-						colorByHash.set(hash);
-					}}>format_paint</IconButton>
+				<div class="top-text">
+					<IconButton
+						size="mini"
+						class="material-icons"
+						style="color: {selectedHashColor}; margin-top: -10px;"
+						on:click={() => {
+							colorByHash.set(hash);
+						}}>format_paint</IconButton>
+				</div>
 			{/if}
 		</div>
 
@@ -338,5 +344,9 @@
 		display: flex;
 		align-items: center;
 		gap: 2px;
+	}
+	.top-text {
+		height: 18px;
+		z-index: 999;
 	}
 </style>


### PR DESCRIPTION
# feat: color select icon and hide colors when not selected on bar chart
<img width="1682" alt="Screen Shot 2022-07-27 at 2 31 57 PM" src="https://user-images.githubusercontent.com/65095341/181346628-3c120f1a-0d87-4721-a70b-b3775b310916.png">

## Summary
1. Added `<IconButton />` to select color in the scatter plot (shows up on hover of `<MetadataCell />`)
2. Only show the colors on bar chart when the color is selected (hide rest)

That's all folks