### PR TITLE
feat: simplified scatterplot in discovery

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,7 @@
         "d3-shape": "^3.1.0",
         "html2pdf.js": "^0.10.1",
         "internmap": "^2.0.3",
+        "pub-sub-es": "^2.0.1",
         "regl-scatterplot": "^1.3.0",
         "sirv-cli": "^2.0.0",
         "svelte-spa-router": "^3.3.0",
@@ -8714,9 +8715,9 @@
       }
     },
     "node_modules/regl-scatterplot": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/regl-scatterplot/-/regl-scatterplot-1.3.0.tgz",
-      "integrity": "sha512-HobgXk8Sa8A8HeqxARXZx44dI7q+mvbF5sncIG0Z3vEHBJEA5nGxw9vM9vypGIl9HivL7vA72o107r+hxxi6fw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/regl-scatterplot/-/regl-scatterplot-1.3.1.tgz",
+      "integrity": "sha512-GbZp5zxzLJAGy6vMJ13cvXyKcrerNPjl+gz3z4NwgncnW3rPZvkAjX3J8vfWS9fMrEnr+L8Vd55gk5ovZfBmYw==",
       "dependencies": {
         "@flekschas/utils": "^0.29.0",
         "dom-2d-camera": "~2.2.3",
@@ -17155,9 +17156,9 @@
       }
     },
     "regl-scatterplot": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/regl-scatterplot/-/regl-scatterplot-1.3.0.tgz",
-      "integrity": "sha512-HobgXk8Sa8A8HeqxARXZx44dI7q+mvbF5sncIG0Z3vEHBJEA5nGxw9vM9vypGIl9HivL7vA72o107r+hxxi6fw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/regl-scatterplot/-/regl-scatterplot-1.3.1.tgz",
+      "integrity": "sha512-GbZp5zxzLJAGy6vMJ13cvXyKcrerNPjl+gz3z4NwgncnW3rPZvkAjX3J8vfWS9fMrEnr+L8Vd55gk5ovZfBmYw==",
       "requires": {
         "@flekschas/utils": "^0.29.0",
         "dom-2d-camera": "~2.2.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -68,6 +68,7 @@
     "d3-shape": "^3.1.0",
     "html2pdf.js": "^0.10.1",
     "internmap": "^2.0.3",
+    "pub-sub-es": "^2.0.1",
     "regl-scatterplot": "^1.3.0",
     "sirv-cli": "^2.0.0",
     "svelte-spa-router": "^3.3.0",

--- a/frontend/src/discovery/Discovery.svelte
+++ b/frontend/src/discovery/Discovery.svelte
@@ -16,7 +16,7 @@
 <main>
 	{#if !tableEmpty}
 		<div id="sidebar-view">
-			<MetadataPanel />
+			<MetadataPanel shouldColor />
 		</div>
 
 		<div id="main-view">

--- a/frontend/src/discovery/EmbedView.svelte
+++ b/frontend/src/discovery/EmbedView.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import Scatter from "./scatter/Scatter.svelte";
-
+	import { colorSpec } from "../stores";
+	import type { ScatterRowsWithIds } from "./scatter/scatter";
 	import { onMount } from "svelte";
 	import { model } from "../stores";
 	import request from "../util/request";
@@ -21,6 +22,18 @@
 	};
 
 	let initialProj: I2D[] = [];
+
+	$: data = initialProj.map((d, i) => {
+		return {
+			id: i.toString(),
+			x: d[0],
+			y: d[1],
+			colorIndex: $colorSpec.labels[i].colorIndex,
+			opacity: 0.65,
+		};
+	}) as ScatterRowsWithIds<string>;
+	$: colorRange = [...$colorSpec.colors];
+
 	onMount(async () => {
 		const projRequest = await project({ model: $model });
 		if (projRequest !== undefined) {
@@ -37,9 +50,12 @@
 <div>
 	<div>Embedding View</div>
 	<div>{initialProj.length}</div>
-	<Scatter width={500} height={500} />
+	<Scatter
+		{data}
+		{colorRange}
+		width={500}
+		height={500}
+		on:lasso={({ detail }) => {
+			console.log(detail);
+		}} />
 </div>
-
-<style>
-	/*  put stuff here */
-</style>

--- a/frontend/src/discovery/EmbedView.svelte
+++ b/frontend/src/discovery/EmbedView.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import Scatter from "./scatter/Scatter.svelte";
+
 	import { onMount } from "svelte";
 	import { model } from "../stores";
 	import request from "../util/request";
@@ -35,6 +37,7 @@
 <div>
 	<div>Embedding View</div>
 	<div>{initialProj.length}</div>
+	<Scatter width={500} height={500} />
 </div>
 
 <style>

--- a/frontend/src/discovery/scatter/AutoScaleRegl.svelte
+++ b/frontend/src/discovery/scatter/AutoScaleRegl.svelte
@@ -2,7 +2,6 @@
 	import LowLevelRegl from "./LowLevelRegl.svelte";
 	import { scaleLinear } from "d3-scale";
 	import { extentXY } from "../../util/util";
-	import type { Extent, XYExtent } from "../../util/util";
 	import type { ScatterRows, ReglConfig, ColorRange } from "./scatter";
 
 	export let width: number;

--- a/frontend/src/discovery/scatter/AutoScaleRegl.svelte
+++ b/frontend/src/discovery/scatter/AutoScaleRegl.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+	import LowLevelRegl from "./LowLevelRegl.svelte";
+	import { scaleLinear } from "d3-scale";
+	import { extentXY } from "../../util/util";
+	import type { Extent, XYExtent } from "../../util/util";
+	import type { ScatterRows, ReglConfig, ColorRange } from "./scatter";
+
+	export let width: number;
+	export let height: number;
+	export let data: ScatterRows = [];
+	export let colorRange: ColorRange = [];
+	export let config: ReglConfig = {};
+
+	// eachDim will do a separate scale based on min and max of each x and y independently
+	// maxDim will scale by the larger min max of the x and y min maxs
+	// maxDim makes the interval in the space the same for x and y axis, eachDim does not
+	export let downScale: "eachDim" | "maxDim" = "maxDim";
+
+	$: downScaler =
+		downScale === "maxDim" ? adjustExtentToFit : (extent: XYExtent) => extent;
+	$: minMax = downScaler(
+		extentXY(
+			data,
+			(d) => d.x,
+			(d) => d.y
+		)
+	);
+	$: xExtent = minMax.xExtent;
+	$: yExtent = minMax.yExtent;
+	const webGLExtent = [-1, 1];
+
+	$: xScale = scaleLinear()
+		.domain([xExtent.min, xExtent.max])
+		.range(webGLExtent);
+	$: yScale = scaleLinear()
+		.domain([yExtent.min, yExtent.max])
+		.range(webGLExtent);
+	$: fitPoints = data.map((p) => {
+		return { ...p, x: xScale(p.x), y: yScale(p.y) };
+	});
+
+	function extentRange(extent: Extent) {
+		return extent.max - extent.min;
+	}
+	function fitSmallerExtent(
+		largerRange: number,
+		smallerExtent: Extent
+	): Extent {
+		const smallerMidpoint = (smallerExtent.min + smallerExtent.max) / 2;
+		const halfRange = largerRange / 2;
+		return {
+			min: smallerMidpoint - halfRange,
+			max: smallerMidpoint + halfRange,
+		};
+	}
+	function adjustExtentToFit(extent: XYExtent): XYExtent {
+		let newExtent = { xExtent: null, yExtent: null };
+		const xRange = extentRange(extent.xExtent);
+		const yRange = extentRange(extent.yExtent);
+
+		if (xRange > yRange) {
+			newExtent.yExtent = fitSmallerExtent(xRange, extent.yExtent);
+			newExtent.xExtent = extent.xExtent;
+		} else {
+			newExtent.xExtent = fitSmallerExtent(yRange, extent.xExtent);
+			newExtent.yExtent = extent.yExtent;
+		}
+		return newExtent;
+	}
+</script>
+
+<LowLevelRegl
+	on:lassoIndex
+	data={fitPoints}
+	{height}
+	{width}
+	{config}
+	{colorRange} />

--- a/frontend/src/discovery/scatter/LowLevelRegl.svelte
+++ b/frontend/src/discovery/scatter/LowLevelRegl.svelte
@@ -25,6 +25,12 @@
 	$: fixedPoints = minorToMajorRegl(data, colorIndexShift);
 	$: fudgeColorShift = new Array(colorIndexShift).fill("#cccccc");
 	$: fixedColorRange = [...fudgeColorShift, ...colorRange];
+	$: {
+		// make sure this is not called before we actually create the scatterPtr
+		if (scatterPtr && data.length > 0) {
+			draw(fixedPoints);
+		}
+	}
 
 	let scatterPtr: ReglScatterReference;
 	let canvasEl: HTMLCanvasElement;
@@ -36,22 +42,15 @@
 			height,
 			...config,
 		});
-
-		// point[0] is x and point [1] is y
-		// then...
-		// set point[2] as the color
 		scatterPtr.set({
 			colorBy: "category",
 			pointColor: fixedColorRange,
 		});
-		// set point[3] as the opacity
 		scatterPtr.set({
 			opacityBy: "value",
 			opacity: opacityRange(10),
 		});
-
 		dispatchLasso();
-		draw(fixedPoints);
 	});
 	onDestroy(() => {
 		scatterPtr.destroy();
@@ -112,7 +111,3 @@
 </script>
 
 <canvas bind:this={canvasEl} {width} {height} />
-
-<style>
-	/*  put stuff here */
-</style>

--- a/frontend/src/discovery/scatter/LowLevelRegl.svelte
+++ b/frontend/src/discovery/scatter/LowLevelRegl.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
 	import { onDestroy, onMount, createEventDispatcher } from "svelte";
 	import createScatterPlot from "regl-scatterplot";
-	import type { ScatterRows, ReglScatterColumns } from "../scatter";
-	import type { Properties } from "regl-scatterplot/dist/types";
+	import type {
+		ScatterRows,
+		ReglScatterColumns,
+		ReglConfig,
+		ColorRange,
+	} from "./scatter";
 
 	type ReglScatterReference = ReturnType<typeof createScatterPlot>;
 
@@ -11,8 +15,8 @@
 	export let width: number;
 	export let height: number;
 	export let data: ScatterRows = [];
-	export let colorRange: string[] = [];
-	export let config: Partial<Properties> = {};
+	export let colorRange: ColorRange = [];
+	export let config: ReglConfig = {};
 
 	// format data that regl-scatterplot expects
 	// change the {}[] to {} with arrays inside

--- a/frontend/src/discovery/scatter/LowLevelRegl.svelte
+++ b/frontend/src/discovery/scatter/LowLevelRegl.svelte
@@ -25,10 +25,22 @@
 	$: fixedPoints = minorToMajorRegl(data, colorIndexShift);
 	$: fudgeColorShift = new Array(colorIndexShift).fill("#cccccc");
 	$: fixedColorRange = [...fudgeColorShift, ...colorRange];
+
 	$: {
 		// make sure this is not called before we actually create the scatterPtr
 		if (scatterPtr && data.length > 0) {
 			draw(fixedPoints);
+		}
+	}
+
+	// update when the colorRange changes, but now when the scatter changes
+	$: updateColorRange(colorRange);
+	function updateColorRange(colorRange: ColorRange) {
+		if (scatterPtr && colorRange) {
+			scatterPtr.set({
+				colorBy: "category",
+				pointColor: fixedColorRange,
+			});
 		}
 	}
 

--- a/frontend/src/discovery/scatter/Scatter.svelte
+++ b/frontend/src/discovery/scatter/Scatter.svelte
@@ -1,24 +1,30 @@
 <script lang="ts">
-	import LowLevelRegl from "./v2/LowLevelRegl.svelte";
+	import { createEventDispatcher } from "svelte";
+	import AutoScaleRegl from "./AutoScaleRegl.svelte";
+	import type { ScatterRowsWithIds, ReglConfig, ColorRange } from "./scatter";
 
-	interface ScatterPoint {
-		x: number;
-		y: number;
-		color?: string;
-		opacity?: number;
-		size?: number;
-		id?: string;
-	}
-	export let points: ScatterPoint[] = [];
+	const dispatch = createEventDispatcher();
+
+	export let data: ScatterRowsWithIds<string> = [];
 	export let width = 500;
 	export let height = 500;
+	export let colorRange: ColorRange = [];
+	export let config: ReglConfig = {};
 </script>
 
-<LowLevelRegl
+<AutoScaleRegl
+	{data}
+	downScale="maxDim"
 	on:lassoIndex={({ detail }) => {
-		console.log(detail);
+		if (detail !== null) {
+			const indexToInstanceMapping = detail.map((index) => data[index]);
+			dispatch("lasso", indexToInstanceMapping);
+		} else {
+			dispatch("lasso", null);
+		}
 	}}
-	colorRange={["#ff0000", "#00ff00", "#0000ff"]}
+	{colorRange}
+	{config}
 	{width}
 	{height} />
 

--- a/frontend/src/discovery/scatter/Scatter.svelte
+++ b/frontend/src/discovery/scatter/Scatter.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	import LowLevelRegl from "./v2/LowLevelRegl.svelte";
+
+	interface ScatterPoint {
+		x: number;
+		y: number;
+		color?: string;
+		opacity?: number;
+		size?: number;
+		id?: string;
+	}
+	export let points: ScatterPoint[] = [];
+	export let width = 500;
+	export let height = 500;
+</script>
+
+<LowLevelRegl
+	on:lassoIndex={({ detail }) => {
+		console.log(detail);
+	}}
+	colorRange={["#ff0000", "#00ff00", "#0000ff"]}
+	{width}
+	{height} />
+
+<style>
+</style>

--- a/frontend/src/discovery/scatter/scatter.ts
+++ b/frontend/src/discovery/scatter/scatter.ts
@@ -21,18 +21,6 @@ export interface ReglScatterColumns {
 export type ReglConfig = Partial<Properties>;
 export type ColorRange = string[];
 
-export interface LegendaryScatterPoint {
-	x: number;
-	y: number;
-	color: number;
-	opacity: number;
-	id?: unknown;
-}
-export interface LegendaryLegendEntry {
-	color: string;
-	value: string;
-}
-
 export function opacify(colorObj: RGBColor | HSLColor, opacity: number) {
 	const colorCopy = colorObj.copy();
 	colorCopy.opacity = opacity;

--- a/frontend/src/discovery/scatter/scatter.ts
+++ b/frontend/src/discovery/scatter/scatter.ts
@@ -9,6 +9,7 @@ export interface ScatterPoint {
 	opacity: number;
 }
 export type ScatterRows = ScatterPoint[];
+export type ScatterRowsWithIds<T> = ScatterRows & { id?: T };
 
 //column format
 export interface ReglScatterColumns {

--- a/frontend/src/discovery/scatter/scatter.ts
+++ b/frontend/src/discovery/scatter/scatter.ts
@@ -1,0 +1,36 @@
+import type { HSLColor, RGBColor } from "d3-color";
+
+// row format
+export interface ScatterPoint {
+	x: number;
+	y: number;
+	colorIndex: number;
+	opacity: number;
+}
+export type ScatterRows = ScatterPoint[];
+
+//column format
+export interface ReglScatterColumns {
+	x: number[];
+	y: number[];
+	category: number[]; //notice color is now category
+	value: number[]; // notice opacity is now value
+}
+
+export interface LegendaryScatterPoint {
+	x: number;
+	y: number;
+	color: number;
+	opacity: number;
+	id?: unknown;
+}
+export interface LegendaryLegendEntry {
+	color: string;
+	value: string;
+}
+
+export function opacify(colorObj: RGBColor | HSLColor, opacity: number) {
+	const colorCopy = colorObj.copy();
+	colorCopy.opacity = opacity;
+	return colorCopy;
+}

--- a/frontend/src/discovery/scatter/scatter.ts
+++ b/frontend/src/discovery/scatter/scatter.ts
@@ -1,3 +1,4 @@
+import type { Properties } from "regl-scatterplot/dist/types";
 import type { HSLColor, RGBColor } from "d3-color";
 
 // row format
@@ -16,6 +17,8 @@ export interface ReglScatterColumns {
 	category: number[]; //notice color is now category
 	value: number[]; // notice opacity is now value
 }
+export type ReglConfig = Partial<Properties>;
+export type ColorRange = string[];
 
 export interface LegendaryScatterPoint {
 	x: number;

--- a/frontend/src/discovery/scatter/v2/LowLevelRegl.svelte
+++ b/frontend/src/discovery/scatter/v2/LowLevelRegl.svelte
@@ -1,0 +1,114 @@
+<script lang="ts">
+	import { onDestroy, onMount, createEventDispatcher } from "svelte";
+	import createScatterPlot from "regl-scatterplot";
+	import type { ScatterRows, ReglScatterColumns } from "../scatter";
+	import type { Properties } from "regl-scatterplot/dist/types";
+
+	type ReglScatterReference = ReturnType<typeof createScatterPlot>;
+
+	const dispatch = createEventDispatcher();
+
+	export let width: number;
+	export let height: number;
+	export let data: ScatterRows = [];
+	export let colorRange: string[] = [];
+	export let config: Partial<Properties> = {};
+
+	// format data that regl-scatterplot expects
+	// change the {}[] to {} with arrays inside
+	// shift colors down to regl-scatterplot reads as categorical color
+	const colorIndexShift = 2;
+	$: fixedPoints = minorToMajorRegl(data, colorIndexShift);
+	$: fudgeColorShift = new Array(colorIndexShift).fill("#cccccc");
+	$: fixedColorRange = [...fudgeColorShift, ...colorRange];
+
+	let scatterPtr: ReglScatterReference;
+	let canvasEl: HTMLCanvasElement;
+
+	onMount(() => {
+		scatterPtr = createScatterPlot({
+			canvas: canvasEl,
+			width,
+			height,
+			...config,
+		});
+
+		// point[0] is x and point [1] is y
+		// then...
+		// set point[2] as the color
+		scatterPtr.set({
+			colorBy: "category",
+			pointColor: fixedColorRange,
+		});
+		// set point[3] as the opacity
+		scatterPtr.set({
+			opacityBy: "value",
+			opacity: opacityRange(10),
+		});
+
+		dispatchLasso();
+		draw(fixedPoints);
+	});
+	onDestroy(() => {
+		scatterPtr.destroy();
+	});
+
+	function draw(points: ReglScatterColumns) {
+		if (scatterPtr) {
+			scatterPtr.draw(points, {
+				transition: true,
+				transitionDuration: 1200,
+			});
+		}
+	}
+	function dispatchLasso() {
+		if (scatterPtr) {
+			scatterPtr.subscribe(
+				"deselect",
+				() => {
+					dispatch("lassoIndex", null);
+				},
+				null
+			);
+			scatterPtr.subscribe(
+				"select",
+				(d) => {
+					if (d) {
+						dispatch("lassoIndex", d["points"]);
+					}
+				},
+				null
+			);
+		}
+	}
+	function minorToMajorRegl(
+		data: ScatterRows,
+		colorShift = 2
+	): ReglScatterColumns {
+		const major = {
+			x: [],
+			y: [],
+			category: [], // color
+			value: [], // opacity
+		};
+
+		data.forEach((minor) => {
+			major.x.push(minor.x);
+			major.y.push(minor.y);
+			major.category.push(minor.colorIndex + colorShift);
+			major.value.push(minor.opacity);
+		});
+
+		return major;
+	}
+
+	function opacityRange(n = 10) {
+		return new Array(n).fill(0).map((_, i) => (i + 1) / n);
+	}
+</script>
+
+<canvas bind:this={canvasEl} {width} {height} />
+
+<style>
+	/*  put stuff here */
+</style>

--- a/frontend/src/global.d.ts
+++ b/frontend/src/global.d.ts
@@ -73,17 +73,13 @@ interface ZenoColumn {
 	transform?: string;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-namespace Pipeline {
-	export type Projection = { proj: [number, number]; id: string };
-	export interface State {
-		projection: Projection[];
-	}
-	export interface Node {
-		state: Partial<State>;
-		type: string;
-		id: string;
-	}
+interface Extent {
+	min: number;
+	max: number;
+}
+interface XYExtent {
+	xExtent: Extent;
+	yExtent: Extent;
 }
 
 declare namespace svelte.JSX {

--- a/frontend/src/util/util.ts
+++ b/frontend/src/util/util.ts
@@ -322,10 +322,9 @@ export function extentXY<T>(
  * extent is a general implementation over n dimensions to get min and max values
  */
 export function extent<T>(data: T[], getters: ((d: T) => number)[]): Extent[] {
-	const firstPoint = data[0];
-	const extents: Extent[] = getters.map((getter) => ({
-		min: getter(firstPoint),
-		max: getter(firstPoint),
+	const extents: Extent[] = getters.map(() => ({
+		min: Infinity,
+		max: -Infinity,
 	}));
 
 	data.forEach((d) => {

--- a/frontend/src/util/util.ts
+++ b/frontend/src/util/util.ts
@@ -24,6 +24,15 @@ import {
 } from "../stores";
 import { ZenoColumnType } from "../globals";
 
+export interface Extent {
+	min: number;
+	max: number;
+}
+export interface XYExtent {
+	xExtent: Extent;
+	yExtent: Extent;
+}
+
 const PREDICATE_MAP = {
 	"": "",
 	AND: "&&",
@@ -295,32 +304,41 @@ export function enforce({ rule, name }: { rule: boolean; name: string }) {
 	}
 }
 
+/**
+ * extentXY returns the minimum and maximum values for each dimension X and Y
+ */
 export function extentXY<T>(
 	data: T[],
 	xGetter = (d: T) => d[0],
 	yGetter = (d: T) => d[1]
-) {
-	const firstPoint = data[0];
-	const xExtent = { min: xGetter(firstPoint), max: xGetter(firstPoint) };
-	const yExtent = { min: yGetter(firstPoint), max: yGetter(firstPoint) };
-	for (let i = 1; i < data.length; i++) {
-		const value = data[i];
-		const xValue = xGetter(value),
-			yValue = yGetter(value);
-		// mins
-		if (xValue < xExtent.min) {
-			xExtent.min = xValue;
-		}
-		if (yValue < yExtent.min) {
-			yExtent.min = yValue;
-		}
-		// maxs
-		if (xValue > xExtent.max) {
-			xExtent.max = xValue;
-		}
-		if (yValue > yExtent.max) {
-			yExtent.max = yValue;
-		}
-	}
+): XYExtent {
+	const getters = [xGetter, yGetter];
+	const extents: Extent[] = extent(data, getters);
+	const [xExtent, yExtent] = extents;
 	return { xExtent, yExtent };
+}
+
+/**
+ * extent is a general implementation over n dimensions to get min and max values
+ */
+export function extent<T>(data: T[], getters: ((d: T) => number)[]): Extent[] {
+	const firstPoint = data[0];
+	const extents: Extent[] = getters.map((getter) => ({
+		min: getter(firstPoint),
+		max: getter(firstPoint),
+	}));
+
+	data.forEach((d) => {
+		getters.forEach((getter, i) => {
+			const value = getter(d);
+			const extent = extents[i];
+			if (value < extent.min) {
+				extent.min = value;
+			}
+			if (value > extent.max) {
+				extent.max = value;
+			}
+		});
+	});
+	return extents;
 }

--- a/frontend/src/util/util.ts
+++ b/frontend/src/util/util.ts
@@ -24,15 +24,6 @@ import {
 } from "../stores";
 import { ZenoColumnType } from "../globals";
 
-export interface Extent {
-	min: number;
-	max: number;
-}
-export interface XYExtent {
-	xExtent: Extent;
-	yExtent: Extent;
-}
-
 const PREDICATE_MAP = {
 	"": "",
 	AND: "&&",


### PR DESCRIPTION
# feat: simplified scatterplot in discovery
<img width="1264" alt="Screen Shot 2022-09-20 at 1 41 47 AM" src="https://user-images.githubusercontent.com/65095341/191211252-f0d143f7-83de-47f1-80b0-c738093251ed.png">


As the name suggests, I brought back the scatterplot. Right now it just visualizes the bare minimum UMAP projection of the embeddings. The lasso select is not yet hooked up to showing the samples for the selected.

I massively rewrote everything to simplify, but it still uses the regl-scatterplot library. Just to update you.

Some weirdness. With [regl-scatterplot](https://github.com/flekschas/regl-scatterplot/blob/master/README.md), It asks me to install pub-sub-es in the docs (see quote block)
> npm i regl-scatterplot regl pub-sub-es
FYI, regl-scatterplot doesn't bundle regl and pub-sub-es, which is why you have to install them separately.

pub-sub-es installed or not didn't seem to matter before, but I added it because the library asks for it. No errors either way. I'll have to look to see why this extra logging library is necessary. 