### PR TITLE
fix: error when IPython module doesn't exist

### DIFF
--- a/zeno/util.py
+++ b/zeno/util.py
@@ -127,5 +127,5 @@ def is_notebook() -> bool:
             return False  # Terminal running IPython
         else:
             return False  # Other type (?)
-    except ImportError:
+    except (NameError, ImportError):
         return False  # Probably standard Python interpreter

--- a/zeno/util.py
+++ b/zeno/util.py
@@ -127,5 +127,5 @@ def is_notebook() -> bool:
             return False  # Terminal running IPython
         else:
             return False  # Other type (?)
-    except NameError:
+    except ImportError:
         return False  # Probably standard Python interpreter


### PR DESCRIPTION
When doing `except NameError`
![Screenshot 2023-01-23 at 7 19 04 PM](https://user-images.githubusercontent.com/65095341/214206013-6d57bcf4-ec68-4313-aeba-f09403f17608.png)

Works fine when doing `except ImportError` (specifically for "no module exists")

I'm on python `3.10.8`