### PR TITLE
fix: lru_cache on class methods introduces leaks

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -456,6 +456,24 @@ files = [
 ]
 
 [[package]]
+name = "methodtools"
+version = "0.4.5"
+description = "Expand standard functools to methods"
+category = "main"
+optional = false
+python-versions = "*"
+files = [
+    {file = "methodtools-0.4.5.tar.gz", hash = "sha256:9370156e9036789e98cf0e97355b3be3bcd7cc9e520d1e15893a1407719effb2"},
+]
+
+[package.dependencies]
+wirerope = ">=0.4.5"
+
+[package.extras]
+doc = ["sphinx"]
+test = ["functools32 (>=3.2.3-2)", "pytest (==4.6.7)", "pytest-cov (==2.6.1)"]
+
+[[package]]
 name = "moreorless"
 version = "0.4.0"
 description = "Python diff wrapper"
@@ -1537,7 +1555,25 @@ files = [
     {file = "websockets-10.4.tar.gz", hash = "sha256:eef610b23933c54d5d921c92578ae5f89813438fded840c2e9809d378dc765d3"},
 ]
 
+[[package]]
+name = "wirerope"
+version = "0.4.6"
+description = "'Turn functions and methods into fully controllable objects'"
+category = "main"
+optional = false
+python-versions = "*"
+files = [
+    {file = "wirerope-0.4.6.tar.gz", hash = "sha256:bd1a151d4133b3ce30ecb76ed92f861505f688151173d22be2e29f4f02e60392"},
+]
+
+[package.dependencies]
+six = ">=1.11.0"
+
+[package.extras]
+doc = ["sphinx"]
+test = ["pytest (==4.6.7)", "pytest-cov (==2.6.1)"]
+
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8, <=3.11" 
-content-hash = "14c222a86f23c7bbe21ea3b3570100b03f3006bbe4d4b2c0e9e4a55563050b5f"
+content-hash = "e4993a83d76500bc99233490bff5794db904cbca6ad5490de22f3eeef2c4d0db"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ types-setuptools = "^65.4.0"
 types-tqdm = "^4.64.7"
 uvicorn = ">=0.17.5,<0.21.0"
 websockets = "^10.2"
+methodtools = "^0.4.5"
 
 [tool.poetry.dev-dependencies]
 black = "^22.12.0"

--- a/zeno/data_pipeline/zeno_backend.py
+++ b/zeno/data_pipeline/zeno_backend.py
@@ -6,7 +6,7 @@ import os
 import pickle
 import sys
 import threading
-from functools import lru_cache
+from methodtools import lru_cache
 from inspect import getsource
 from math import isnan
 from pathlib import Path
@@ -552,7 +552,9 @@ class ZenoBackend(object):
         exists = str(embed_column) in self.df.columns
         return exists and not self.df[str(embed_column)].isnull().any()
 
-    @lru_cache
+    @lru_cache(
+        maxsize=5
+    )  # will cache up 5 model projections in memory before needing to recompute
     def run_tsne(self, model: str) -> np.ndarray:
         # Extract embeddings and store in one big ndarray
         embed_col = ZenoColumn(column_type=ZenoColumnType.EMBEDDING, name=model)

--- a/zeno/data_pipeline/zeno_backend.py
+++ b/zeno/data_pipeline/zeno_backend.py
@@ -6,7 +6,6 @@ import os
 import pickle
 import sys
 import threading
-from methodtools import lru_cache
 from inspect import getsource
 from math import isnan
 from pathlib import Path
@@ -14,6 +13,7 @@ from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
+from methodtools import lru_cache  # type: ignore
 from pandas import DataFrame  # type: ignore
 from pathos.multiprocessing import ProcessingPool as Pool  # type: ignore
 from sklearn import preprocessing  # type: ignore


### PR DESCRIPTION
when 

```python
class Cheese:
    def __init__(self, animal: str):
        self.animal = animal;

    @functools.lru_cache
    def num_holes(self, weight: float):
        return Infinity
```

apparently even when the created object `swiss = Cheese("cow")` goes out of scope, the memory within swiss is not garbage collected (like animal) if num_holes was called at some point.

This is because `functools.lru_cache` looks at the parameters of numHoles, and self happens to be one of them. Somehow this leads to weirdness as described in #522.

I switched to `methodtools.lru_cache` which is the same thing, but handles for classes.