### PR TITLE
fix: color legend in wrong order

### DIFF
--- a/frontend/src/instance-views/scatter-view/ScatterLegend.svelte
+++ b/frontend/src/instance-views/scatter-view/ScatterLegend.svelte
@@ -48,7 +48,7 @@
 		<div class="legend-label">FALSE</div>
 	</div>
 {:else if metadataType === "nominal"}
-	{#each domain as d, i}
+	{#each domain.sort() as d, i}
 		<div class="legend-item">
 			<div
 				class="legend-color"


### PR DESCRIPTION
example of error from #534
![Screenshot 2023-01-30 at 7 59 09 PM](https://user-images.githubusercontent.com/65095341/215672620-a54eaf1d-56e9-40b8-b629-74f8ac6a8200.png)

notice the legend colors.

Not sure if I'm covering up some underlying issues, but alphabetical sort fixes the legend.