### PR TITLE
fix: remove text highlight for drag or click in scatter

### DIFF
--- a/frontend/src/instance-views/scatter-view/ScatterView.svelte
+++ b/frontend/src/instance-views/scatter-view/ScatterView.svelte
@@ -210,10 +210,9 @@
 						{#if pointHover !== undefined}
 							<div
 								id="hover-view"
-								style:width="{100}px"
-								style:height="{80}px"
-								style:left="{pointHover.canvasX + 5}px"
-								style:top="{pointHover.canvasY + 5}px">
+								class="no-text-highlight"
+								style:left="{pointHover.canvasX + hoverViewOffset}px"
+								style:top="{pointHover.canvasY + hoverViewOffset}px">
 								<div id="replace-view" bind:this={hoverViewDivEl} />
 							</div>
 						{/if}
@@ -301,5 +300,16 @@
 		padding-top: 20px;
 		box-shadow: 0px 0px 1px 1px hsla(0, 0%, 30%, 0.1);
 		border-radius: 3px;
+	}
+
+	/* https://stackoverflow.com/questions/826782/how-to-disable-text-selection-highlighting */
+	.no-text-highlight {
+		-webkit-touch-callout: none; /* iOS Safari */
+		-webkit-user-select: none; /* Safari */
+		-khtml-user-select: none; /* Konqueror HTML */
+		-moz-user-select: none; /* Old versions of Firefox */
+		-ms-user-select: none; /* Internet Explorer/Edge */
+		user-select: none; /* Non-prefixed version, currently
+									supported by Chrome, Edge, Opera and Firefox */
 	}
 </style>

--- a/frontend/src/instance-views/scatter-view/ScatterView.svelte
+++ b/frontend/src/instance-views/scatter-view/ScatterView.svelte
@@ -36,6 +36,7 @@
 	export let viewOptions = {};
 	export let autoResize = true;
 
+	const hoverViewOffset = 10;
 	let height = 850; // canvas dims
 	let width = 1000; // canvas dims
 	let pointSizeSlider = 3;

--- a/frontend/src/instance-views/scatter-view/ScatterView.svelte
+++ b/frontend/src/instance-views/scatter-view/ScatterView.svelte
@@ -310,7 +310,6 @@
 		-khtml-user-select: none; /* Konqueror HTML */
 		-moz-user-select: none; /* Old versions of Firefox */
 		-ms-user-select: none; /* Internet Explorer/Edge */
-		user-select: none; /* Non-prefixed version, currently
-									supported by Chrome, Edge, Opera and Firefox */
+		user-select: none; /* Non-prefixed version, currently supported by Chrome, Edge, Opera and Firefox */
 	}
 </style>


### PR DESCRIPTION
## Text highlights on drag or click because of the instance view (my text highlight is pink)
https://user-images.githubusercontent.com/65095341/216883172-e383518b-5cf1-43de-bdfa-620ad0f3a3e6.mov

## Remove the text highlight on it!
https://user-images.githubusercontent.com/65095341/216883178-13072002-0978-4bc3-a21d-ad47c483b18f.mov

