### PR TITLE
feat: add way to estimate best number of bins for a histogram

### DIFF
--- a/examples/cifar/tests/metrics.py
+++ b/examples/cifar/tests/metrics.py
@@ -23,7 +23,7 @@ def f1(df, ops: ZenoOptions):
 
 @distill
 def incorrect(df, ops: ZenoOptions):
-    return (df[ops.label_column] != df[ops.output_column]).tolist()
+    return df[ops.label_column] != df[ops.output_column]
 
 
 @distill

--- a/zeno/backend.py
+++ b/zeno/backend.py
@@ -346,7 +346,7 @@ class ZenoBackend(object):
                 for out in post_outputs:
                     self.df.loc[:, str(out[0])] = out[1]  # type: ignore
                     self.df[str(out[0])] = self.df[str(out[0])].convert_dtypes()
-                    out[0].metadata_type = getMetadataType(out[1])
+                    out[0].metadata_type = getMetadataType(self.df[str(out[0])])
                     self.complete_columns.append(out[0])
 
     def get_metrics_for_slices(

--- a/zeno/classes/metadata.py
+++ b/zeno/classes/metadata.py
@@ -5,8 +5,8 @@ from zeno.classes.slice import FilterIds, FilterPredicateGroup
 
 
 class HistogramBucket(CamelModel):
-    bucket: Union[int, float, bool, str]
-    bucket_end: Union[int, float, bool, str, None] = None
+    bucket: Union[float, bool, int, str]
+    bucket_end: Union[float, bool, int, str, None] = None
 
 
 class HistogramColumnRequest(CamelModel):

--- a/zeno/processing/histogram_processing.py
+++ b/zeno/processing/histogram_processing.py
@@ -31,7 +31,8 @@ def compute_optimal_num_bins(
     column: pd.Series, min_bins: int = 10, max_bins: int = 100
 ) -> int:
     """compute_optimal_num_bins computes the best number of bins given a column
-    this uses the [freedman diaconis rule](https://www.wikiwand.com/en/Freedman%E2%80%93Diaconis_rule)
+    this uses the
+    [freedman diaconis rule](https://www.wikiwand.com/en/Freedman%E2%80%93Diaconis_rule)
     which can be replaced later on for something better if we want
 
     Args:

--- a/zeno/processing/histogram_processing.py
+++ b/zeno/processing/histogram_processing.py
@@ -11,6 +11,54 @@ from zeno.classes.metadata import HistogramBucket, HistogramRequest, StringFilte
 from zeno.processing.filtering import filter_table, filter_table_single
 
 
+def interquartile_range(column: pd.Series):
+    Q1 = column.quantile(0.25)
+    Q3 = column.quantile(0.75)
+    IQR = Q3 - Q1
+    return IQR
+
+
+def freeedman_diaconis_rule(column: pd.Series):
+    IQR = interquartile_range(column)
+    n = len(column)
+
+    h = 2 * IQR / (n ** (1 / 3))
+
+    return h
+
+
+def compute_optimal_num_bins(
+    column: pd.Series, min_bins: int = 10, max_bins: int = 100
+) -> int:
+    """compute_optimal_num_bins computes the best number of bins given a column
+    this uses the [freedman diaconis rule](https://www.wikiwand.com/en/Freedman%E2%80%93Diaconis_rule)
+    which can be replaced later on for something better if we want
+
+    Args:
+        column (pd.Series): pandas column
+        min_bins (int, optional): the minimum number of bins we want. Defaults to 10.
+        max_bins (int, optional): the maximum number of bins we want. Defaults to 100.
+
+    Returns:
+        int: the optimal number of bins
+    """
+
+    # compute optimal number of bins
+    optimal_bin_width = freeedman_diaconis_rule(column)
+    if optimal_bin_width <= 0:
+        return min_bins
+    interval = column.max() - column.min()
+    optimal_num_bins = int(interval / optimal_bin_width)
+
+    # make sure the optimal is within the min and max we want
+    if optimal_num_bins > max_bins:
+        return max_bins
+    elif optimal_num_bins < min_bins:
+        return min_bins
+    else:
+        return optimal_num_bins
+
+
 def histogram_buckets(
     df: pd.DataFrame, req: List[ZenoColumn]
 ) -> List[List[HistogramBucket]]:
@@ -27,7 +75,8 @@ def histogram_buckets(
         elif col.metadata_type == MetadataType.CONTINUOUS:
             ret_hist: List[HistogramBucket] = []  # type: ignore
             df_col = df_col.fillna(0)
-            bins = np.histogram_bin_edges(df_col)
+            optimal_num_bins = compute_optimal_num_bins(df_col)
+            bins = np.histogram_bin_edges(df_col, optimal_num_bins)
             for i in range(len(bins) - 1):
                 ret_hist.append(
                     HistogramBucket(

--- a/zeno/processing/histogram_processing.py
+++ b/zeno/processing/histogram_processing.py
@@ -12,7 +12,7 @@ from zeno.processing.filtering import filter_table, filter_table_single
 
 
 def histogram_buckets(
-    df: pd.DataFrame, req: List[ZenoColumn], num_bins: Union[int, str] = "auto"
+    df: pd.DataFrame, req: List[ZenoColumn], num_bins: Union[int, str] = "doane"
 ) -> List[List[HistogramBucket]]:
     """Calculate the histogram buckets for a list of columns.
 
@@ -21,7 +21,7 @@ def histogram_buckets(
         req (List[ZenoColumn]): list of columns to compute buckets for
         num_bins (Union[int, str], optional):
             estimates the best number and size of bins to use.
-            Defaults to "auto", but can be a fixed integer
+            Defaults to "doane", but can be a fixed integer
             Other options can be found
             [here](https://numpy.org/doc/stable/reference/generated/numpy.histogram_bin_edges.html)
     Returns:

--- a/zeno/processing/histogram_processing.py
+++ b/zeno/processing/histogram_processing.py
@@ -21,10 +21,9 @@ def interquartile_range(column: pd.Series):
 def freeedman_diaconis_rule(column: pd.Series):
     IQR = interquartile_range(column)
     n = len(column)
-
-    h = 2 * IQR / (n ** (1 / 3))
-
-    return h
+    # https://www.wikiwand.com/en/Freedman%E2%80%93Diaconis_rule
+    bin_width = 2 * IQR / (n ** (1 / 3))
+    return bin_width
 
 
 def compute_optimal_num_bins(

--- a/zeno/util.py
+++ b/zeno/util.py
@@ -30,7 +30,7 @@ def getMetadataType(col: pd.Series) -> MetadataType:
     except ValueError:
         pass
 
-    if col.dtype == "bool":
+    if col.dtype == "bool" or col.dtype == "boolean":
         return MetadataType.BOOLEAN
 
     try:


### PR DESCRIPTION
Instead of default 10, compute the optimal number of bins per histogram.

<img width="340" alt="Screenshot 2023-02-19 at 12 15 18 PM" src="https://user-images.githubusercontent.com/65095341/219972901-6467a4ce-e92e-40f0-8e72-542b3e3d8755.png">
