### PR TITLE
feat: return other data from @model

### DIFF
--- a/zeno/api.py
+++ b/zeno/api.py
@@ -58,6 +58,44 @@ class ZenoParameters(BaseModel):
         arbitrary_types_allowed = True
 
 
+class ZenoModelBatch:
+    """ZenoModelBatch
+    Save the results from a batch of predictions from the @model decorator callback
+    return value
+
+    Example:
+        return ModelBatch(predictions=[], embeddings=[], times=[], confidences=[])
+
+        OR you can build it up after instantiation (which I (@xnought) greatly prefer)
+
+        return ModelBatch().save_predictions([])
+                           .save_embeddings([])
+                           .save_other("times", [])
+                           .save_other("confidences", [])
+    """
+
+    def __init__(self, predictions=[], embeddings=[], **other):
+        # special returns since we use these in the frontend differently
+        # from the other
+        self._predictions = predictions
+        self._embeddings = embeddings
+
+        # other returns as post-distill basically with user-defined names
+        self._other = other
+
+    def save_predictions(self, predictions):
+        self._predictions = predictions
+        return self
+
+    def save_embeddings(self, embeddings):
+        self._embeddings = embeddings
+        return self
+
+    def save_other(self, column_name: str, data):
+        self._other[column_name] = data
+        return self
+
+
 def model(func):
     @functools.wraps(func)
     def _wrapper(*args, **kwargs):

--- a/zeno/api.py
+++ b/zeno/api.py
@@ -1,7 +1,7 @@
 """External API for Zeno."""
 
 import functools
-from typing import Callable, Dict, List, Union
+from typing import Callable, Dict, List, Union, Optional
 
 from pandas import DataFrame, Series
 from pydantic import BaseModel
@@ -64,28 +64,18 @@ class ZenoModelBatch:
     return value
 
     Example:
-        return ModelBatch().save_predictions([])
-                           .save_embeddings([])
-                           .save_other("times", [])
-                           .save_other("confidences", [])
+        return ModelBatch(predictions=[], embeddings=[], times_ms=[], confidences=[])
     """
 
-    def __init__(self):
-        self._predictions: Union[List, Series, None] = None
-        self._embeddings: Union[List, Series, None] = None
-        self._other: Dict[str, Union[List, Series]] = {}
-
-    def save_predictions(self, predictions: Union[List, Series]):
-        self._predictions = predictions
-        return self
-
-    def save_embeddings(self, embeddings: Union[List, Series]):
-        self._embeddings = embeddings
-        return self
-
-    def save_other(self, column_name: str, data: Union[List, Series]):
-        self._other[column_name] = data
-        return self
+    def __init__(
+        self,
+        predictions: Union[List, Series],
+        embeddings: Optional[Union[List, Series]] = None,
+        **other: Dict[str, Union[List, Series]]
+    ):
+        self.predictions = predictions
+        self.embeddings = embeddings
+        self.other = other
 
 
 def model(func):

--- a/zeno/api.py
+++ b/zeno/api.py
@@ -1,9 +1,9 @@
 """External API for Zeno."""
 
 import functools
-from typing import Callable, Dict, List
+from typing import Callable, Dict, List, Union
 
-from pandas import DataFrame
+from pandas import DataFrame, Series
 from pydantic import BaseModel
 
 
@@ -64,34 +64,26 @@ class ZenoModelBatch:
     return value
 
     Example:
-        return ModelBatch(predictions=[], embeddings=[], times=[], confidences=[])
-
-        OR you can build it up after instantiation (which I (@xnought) greatly prefer)
-
         return ModelBatch().save_predictions([])
                            .save_embeddings([])
                            .save_other("times", [])
                            .save_other("confidences", [])
     """
 
-    def __init__(self, predictions=[], embeddings=[], **other):
-        # special returns since we use these in the frontend differently
-        # from the other
-        self._predictions = predictions
-        self._embeddings = embeddings
+    def __init__(self):
+        self._predictions: Union[List, Series, None] = None
+        self._embeddings: Union[List, Series, None] = None
+        self._other: Dict[str, Union[List, Series]] = {}
 
-        # other returns as post-distill basically with user-defined names
-        self._other = other
-
-    def save_predictions(self, predictions):
+    def save_predictions(self, predictions: Union[List, Series]):
         self._predictions = predictions
         return self
 
-    def save_embeddings(self, embeddings):
+    def save_embeddings(self, embeddings: Union[List, Series]):
         self._embeddings = embeddings
         return self
 
-    def save_other(self, column_name: str, data):
+    def save_other(self, column_name: str, data: Union[List, Series]):
         self._other[column_name] = data
         return self
 


### PR DESCRIPTION
#629 

- [x] Skeleton for the ModelBatch Class (called ZenoModelBatch for now)
- [ ] Either return ZenoModelBatch or what we had before (predictions or (predictions, embeddings))
- [ ] Reproduce the behavior of just saving the predictions and embeddings from ZenoModelBatch
- [ ] Extend to add other data columns that users can add