### PR TITLE
fix: remove report metric field relation w/ size & fix all instance & all instance in heatmap

### DIFF
--- a/frontend/src/api/slice.ts
+++ b/frontend/src/api/slice.ts
@@ -42,7 +42,7 @@ function setModelForMetricKeys(metricKeys: MetricKey[]) {
 
 function setMetricForSize(metricKeys: MetricKey[]) {
 	return metricKeys.map((key) => {
-		key.metric = key.metric === "size" ? "accuracy" : key.metric;
+		key.metric = key.metric === "size" ? "" : key.metric;
 		return key;
 	});
 }
@@ -58,6 +58,9 @@ export async function getMetricsForSlices(
 	if (metricKeys.length === 0) {
 		return null;
 	}
+	// update metric to empty string if metric is size
+	metricKeys = setMetricForSize(metricKeys);
+
 	if (metricKeys[0].metric === undefined) {
 		metricKeys = metricKeys.map((k) => ({ ...k, metric: "" }));
 	}
@@ -66,9 +69,6 @@ export async function getMetricsForSlices(
 	}
 	// Update model in predicates if slices are dependent on postdistill columns.
 	metricKeys = setModelForMetricKeys(metricKeys);
-
-	// use accuracy as default metrics to fetch size metric
-	metricKeys = setMetricForSize(metricKeys);
 
 	if (metricKeys.length > 0) {
 		return await ZenoService.getMetricsForSlices({

--- a/frontend/src/report/bar-chart/BarChartReport.svelte
+++ b/frontend/src/report/bar-chart/BarChartReport.svelte
@@ -42,7 +42,9 @@
 					slices: r.slice,
 					models: r.model,
 					size: res[i].size,
-					metrics: res[i].metric.toFixed(2),
+					...(selectMetrics !== "size" && {
+						metrics: res[i].metric.toFixed(2),
+					}),
 				})),
 			}}
 			<VegaLite

--- a/frontend/src/report/beeswarm-chart/BeeswarmChartReport.svelte
+++ b/frontend/src/report/beeswarm-chart/BeeswarmChartReport.svelte
@@ -124,7 +124,9 @@
 						slices: parameters.yEncoding === "slices" ? yName : r.slice,
 						models: parameters.yEncoding === "models" ? yName : r.model,
 						size: res[r.index].size,
-						metrics: res[r.index].metric.toFixed(2),
+						...(xLabel !== "size" && {
+							metrics: res[r.index].metric.toFixed(2),
+						}),
 					})),
 				}}
 				<h4>{yName}</h4>

--- a/frontend/src/report/heatmap-chart/HeatMapReport.svelte
+++ b/frontend/src/report/heatmap-chart/HeatMapReport.svelte
@@ -49,16 +49,25 @@
 
 					let sli_1_pred = [...sli_1.filterPredicates.predicates];
 					let sli_2_pred = [...sli_2.filterPredicates.predicates];
-					let sec_slice_pred_col_0 = {
-						...sli_2.filterPredicates.predicates[0],
-					};
-					sec_slice_pred_col_0.join = "&";
-					sli_2_pred[0] = sec_slice_pred_col_0;
+					let concat_preds = [];
+
+					// if both are not "all instance" slice
+					if (sli_1_pred.length !== 0 && sli_2_pred.length !== 0) {
+						let sec_slice_pred_col_0 = {
+							...sli_2.filterPredicates.predicates[0],
+						};
+						sec_slice_pred_col_0.join = "&";
+						sli_2_pred[0] = sec_slice_pred_col_0;
+						concat_preds = sli_1_pred.concat(sli_2_pred);
+					} else {
+						concat_preds = sli_1_pred.length === 0 ? sli_2_pred : sli_1_pred;
+					}
+
 					let combined_slice = <Slice>{
 						sliceName: "",
 						folder: "",
 						filterPredicates: {
-							predicates: sli_1_pred.concat(sli_2_pred),
+							predicates: concat_preds,
 							join: "",
 						},
 					};
@@ -84,8 +93,10 @@
 					table: chartEntries.map((r, i) => ({
 						slices: r.slice,
 						size: res[i].size,
-						metrics: res[i].metric.toFixed(2),
 						models: r.model,
+						...(selectMetric !== "size" && {
+							metrics: res[i].metric.toFixed(2),
+						}),
 					})),
 				}}
 				<VegaLite
@@ -105,8 +116,10 @@
 						slice_1: r.slice_1,
 						slice_2: r.slice_2,
 						size: res[i].size,
-						metrics: res[i].metric.toFixed(2),
 						models: r.model,
+						...(selectMetric !== "size" && {
+							metrics: res[i].metric.toFixed(2),
+						}),
 					})),
 				}}
 				<h4>{selectModel}</h4>

--- a/frontend/src/report/line-chart/LineChartReport.svelte
+++ b/frontend/src/report/line-chart/LineChartReport.svelte
@@ -42,7 +42,9 @@
 					slices: r.slice,
 					models: r.model,
 					size: res[i].size,
-					metrics: res[i].metric.toFixed(2),
+					...(selectMetrics !== "size" && {
+						metrics: res[i].metric.toFixed(2),
+					}),
 				})),
 			}}
 			<VegaLite


### PR DESCRIPTION
1. Send empty metric when selecting size metric in report to only fetch size instead of using missing hard-coded metrics, such as "accuracy".
2. Fix all instance & all instance break in heatmap slice vs slice