### PR TITLE
fix: update instance view when sample number ($rowsPerPage) changes

### DIFF
--- a/frontend/src/instance-views/ComparisonView.svelte
+++ b/frontend/src/instance-views/ComparisonView.svelte
@@ -53,6 +53,7 @@
 	$: {
 		$comparisonModels;
 		currentPage;
+		$rowsPerPage;
 		$status.completeColumns;
 		$model;
 		$sort;

--- a/frontend/src/instance-views/ListView.svelte
+++ b/frontend/src/instance-views/ListView.svelte
@@ -48,6 +48,7 @@
 	// when state changes update current table view
 	$: {
 		currentPage;
+		$rowsPerPage;
 		$status.completeColumns;
 		$selections.tags;
 		$model;

--- a/frontend/src/instance-views/TableView.svelte
+++ b/frontend/src/instance-views/TableView.svelte
@@ -70,6 +70,7 @@
 		$model;
 		$sort;
 		$editId, currentPage;
+		$rowsPerPage;
 		updateTable();
 	}
 

--- a/frontend/src/instance-views/TableView.svelte
+++ b/frontend/src/instance-views/TableView.svelte
@@ -64,12 +64,13 @@
 
 	// update on page, metadata selection, slice selection, or state change.
 	$: {
+		currentPage;
 		$status.completeColumns;
 		$selections.tags;
 		$selectionPredicates;
 		$model;
 		$sort;
-		$editId, currentPage;
+		$editId;
 		$rowsPerPage;
 		updateTable();
 	}


### PR DESCRIPTION
Currently when changing sample numbers, the view won't update.
This PR update instance view when changing sample numbers (5,15,30,80,100)