### PR TITLE
refactor: select style for model & metric

### DIFF
--- a/frontend/src/metadata/MetadataPanel.svelte
+++ b/frontend/src/metadata/MetadataPanel.svelte
@@ -528,7 +528,7 @@
 
 <style>
 	select {
-		width: 175px;
+		width: 167px;
 		height: 35px;
 		border: 1px solid var(--G4);
 		border-radius: 5px;

--- a/frontend/src/metadata/MetadataPanel.svelte
+++ b/frontend/src/metadata/MetadataPanel.svelte
@@ -532,6 +532,14 @@
 		height: 35px;
 		border: 1px solid var(--G4);
 		border-radius: 5px;
+		font-size: 14px;
+		color: var(--G1);
+	}
+	option {
+		padding: 5px;
+	}
+	option:checked {
+		background-color: var(--G5);
 	}
 	.options-header {
 		margin-top: 5px;


### PR DESCRIPTION
This PR does some simple styling for model & metric dropdown. 
Since some feature of native select depends on browser default settings, such as the blue color when hovering over options. There are actually few options to style.

