### PR TITLE
refactor: rename 'size' in report to 'slice size'

### DIFF
--- a/frontend/src/api/slice.ts
+++ b/frontend/src/api/slice.ts
@@ -69,7 +69,7 @@ function setModelForMetricKeys(metricKeys: MetricKey[]) {
 
 function setMetricForSize(metricKeys: MetricKey[]) {
 	return metricKeys.map((key) => {
-		key.metric = key.metric === "size" ? "" : key.metric;
+		key.metric = key.metric === "slice size" ? "" : key.metric;
 		return key;
 	});
 }

--- a/frontend/src/report/ReportHome.svelte
+++ b/frontend/src/report/ReportHome.svelte
@@ -27,7 +27,7 @@
 						type: ChartType.BAR,
 						slices: [...Array.from($slices.keys()).slice(0, 2)],
 						models: [...$models.values()],
-						metrics: [...$metrics.values(), "size"],
+						metrics: [...$metrics.values(), "slice size"],
 						parameters: {
 							xEncoding: "slices",
 							yEncoding: "metrics",

--- a/frontend/src/report/bar-chart/BarChartReport.svelte
+++ b/frontend/src/report/bar-chart/BarChartReport.svelte
@@ -42,7 +42,7 @@
 					slices: r.slice,
 					models: r.model,
 					size: res[i].size,
-					...(selectMetrics !== "size" && {
+					...(selectMetrics !== "slice size" && {
 						metrics: res[i].metric.toFixed(2),
 					}),
 				})),

--- a/frontend/src/report/bar-chart/vegaSpec-bar.ts
+++ b/frontend/src/report/bar-chart/vegaSpec-bar.ts
@@ -43,7 +43,7 @@ export default function generateSpec(parameters, selectMetrics): VegaLiteSpec {
 			},
 			y: {
 				title: paramMap[y_encode].title,
-				field: selectMetrics !== "size" ? y_encode : "size",
+				field: selectMetrics !== "slice size" ? y_encode : "size",
 				type: paramMap[y_encode].type,
 				axis: {
 					labelFontSize: 14,
@@ -77,8 +77,8 @@ export default function generateSpec(parameters, selectMetrics): VegaLiteSpec {
 					type: "bar",
 					tooltip: {
 						signal:
-							"{'slice_name': datum.slices,'size': datum.size, " +
-							(selectMetrics !== "size" ? selectMetrics : "accuracy") +
+							"{'slice_name': datum.slices,'slice_size': datum.size, " +
+							(selectMetrics !== "slice size" ? selectMetrics : "accuracy") +
 							": datum.metrics, 'model': datum.models}",
 					},
 				},
@@ -97,7 +97,7 @@ export default function generateSpec(parameters, selectMetrics): VegaLiteSpec {
 				},
 				encoding: {
 					text: {
-						field: selectMetrics !== "size" ? y_encode : "size",
+						field: selectMetrics !== "slice size" ? y_encode : "size",
 						type: paramMap[y_encode].type,
 					},
 				},

--- a/frontend/src/report/beeswarm-chart/BeeswarmChartReport.svelte
+++ b/frontend/src/report/beeswarm-chart/BeeswarmChartReport.svelte
@@ -124,7 +124,7 @@
 						slices: parameters.yEncoding === "slices" ? yName : r.slice,
 						models: parameters.yEncoding === "models" ? yName : r.model,
 						size: res[r.index].size,
-						...(xLabel !== "size" && {
+						...(xLabel !== "slice size" && {
 							metrics: res[r.index].metric.toFixed(2),
 						}),
 					})),

--- a/frontend/src/report/beeswarm-chart/vegaSpec-beeswarm.ts
+++ b/frontend/src/report/beeswarm-chart/vegaSpec-beeswarm.ts
@@ -50,7 +50,7 @@ export default function generateSpec(parameters, xLabel): VisualizationSpec {
 				name: "xscale",
 				domain: {
 					data: "table",
-					field: xLabel !== "size" ? x_encode : "size",
+					field: xLabel !== "slice size" ? x_encode : "size",
 				},
 				range: "width",
 				nice: true,
@@ -100,7 +100,7 @@ export default function generateSpec(parameters, xLabel): VisualizationSpec {
 						fill: { scale: "color", field: z_encode },
 						xfocus: {
 							scale: "xscale",
-							field: xLabel !== "size" ? x_encode : "size",
+							field: xLabel !== "slice size" ? x_encode : "size",
 							band: 0.5,
 						},
 						yfocus: { signal: "cy" },
@@ -117,8 +117,8 @@ export default function generateSpec(parameters, xLabel): VisualizationSpec {
 						zindex: { value: 1 },
 						tooltip: {
 							signal:
-								"{'slice_name': datum.slices,'size': datum.size, " +
-								(xLabel !== "size" ? xLabel : "accuracy") +
+								"{'slice_name': datum.slices,'slice_size': datum.size, " +
+								(xLabel !== "slice size" ? xLabel : "accuracy") +
 								": datum.metrics, 'model': datum.models}",
 						},
 					},

--- a/frontend/src/report/heatmap-chart/HeatMapReport.svelte
+++ b/frontend/src/report/heatmap-chart/HeatMapReport.svelte
@@ -94,7 +94,7 @@
 						slices: r.slice,
 						size: res[i].size,
 						models: r.model,
-						...(selectMetric !== "size" && {
+						...(selectMetric !== "slice size" && {
 							metrics: res[i].metric.toFixed(2),
 						}),
 					})),
@@ -117,7 +117,7 @@
 						slice_2: r.slice_2,
 						size: res[i].size,
 						models: r.model,
-						...(selectMetric !== "size" && {
+						...(selectMetric !== "slice size" && {
 							metrics: res[i].metric.toFixed(2),
 						}),
 					})),

--- a/frontend/src/report/heatmap-chart/vegaSpec-heatmap.ts
+++ b/frontend/src/report/heatmap-chart/vegaSpec-heatmap.ts
@@ -24,7 +24,7 @@ export default function generateSpec(parameters, selectMetrics): VegaLiteSpec {
 				joinaggregate: [
 					{
 						op: "average",
-						field: selectMetrics !== "size" ? "metrics" : "size",
+						field: selectMetrics !== "slice size" ? "metrics" : "size",
 						as: "mean_metrics",
 					},
 				],
@@ -63,7 +63,7 @@ export default function generateSpec(parameters, selectMetrics): VegaLiteSpec {
 						name: "hover",
 						select: {
 							type: "point",
-							field: selectMetrics !== "size" ? "metrics" : "size",
+							field: selectMetrics !== "slice size" ? "metrics" : "size",
 							on: "mouseover",
 						},
 					},
@@ -72,15 +72,15 @@ export default function generateSpec(parameters, selectMetrics): VegaLiteSpec {
 					type: "rect",
 					tooltip: {
 						signal:
-							"{'slice_name': datum.slices,'size': datum.size, " +
-							(selectMetrics !== "size" ? selectMetrics : "accuracy") +
+							"{'slice_name': datum.slices,'slice_size': datum.size, " +
+							(selectMetrics !== "slice size" ? selectMetrics : "accuracy") +
 							": datum.metrics, 'model': datum.models}",
 					},
 				},
 				encoding: {
 					color: {
 						title: selectMetrics,
-						field: selectMetrics !== "size" ? "metrics" : "size",
+						field: selectMetrics !== "slice size" ? "metrics" : "size",
 						type: "quantitative",
 						scale: { scheme: "purples" },
 					},
@@ -100,13 +100,13 @@ export default function generateSpec(parameters, selectMetrics): VegaLiteSpec {
 				mark: { type: "text", fontSize: 12 },
 				encoding: {
 					text: {
-						field: selectMetrics !== "size" ? "metrics" : "size",
+						field: selectMetrics !== "slice size" ? "metrics" : "size",
 						type: "quantitative",
 					},
 					color: {
 						condition: {
 							test:
-								selectMetrics !== "size"
+								selectMetrics !== "slice size"
 									? "datum.metrics < datum.mean_metrics"
 									: "datum.size < datum.mean_metrics",
 							value: "black",

--- a/frontend/src/report/heatmap-chart/vegaSpec-heatmap_slice_vs_slice.ts
+++ b/frontend/src/report/heatmap-chart/vegaSpec-heatmap_slice_vs_slice.ts
@@ -12,7 +12,7 @@ export default function generateSliceVsSliceSpec(selectMetrics): VegaLiteSpec {
 				joinaggregate: [
 					{
 						op: "average",
-						field: selectMetrics !== "size" ? "metrics" : "size",
+						field: selectMetrics !== "slice size" ? "metrics" : "size",
 						as: "mean_metrics",
 					},
 				],
@@ -60,15 +60,15 @@ export default function generateSliceVsSliceSpec(selectMetrics): VegaLiteSpec {
 					type: "rect",
 					tooltip: {
 						signal:
-							"{'slice': datum.slice_1 + ' & ' + datum.slice_2,'size': datum.size, " +
-							(selectMetrics !== "size" ? selectMetrics : "accuracy") +
+							"{'slice': datum.slice_1 + ' & ' + datum.slice_2,'slice_size': datum.size, " +
+							(selectMetrics !== "slice size" ? selectMetrics : "accuracy") +
 							": datum.metrics, 'model': datum.models}",
 					},
 				},
 				encoding: {
 					color: {
 						title: selectMetrics,
-						field: selectMetrics !== "size" ? "metrics" : "size",
+						field: selectMetrics !== "slice size" ? "metrics" : "size",
 						type: "quantitative",
 						scale: { scheme: "purples" },
 					},
@@ -88,13 +88,13 @@ export default function generateSliceVsSliceSpec(selectMetrics): VegaLiteSpec {
 				mark: { type: "text", fontSize: 12 },
 				encoding: {
 					text: {
-						field: selectMetrics !== "size" ? "metrics" : "size",
+						field: selectMetrics !== "slice size" ? "metrics" : "size",
 						type: "quantitative",
 					},
 					color: {
 						condition: {
 							test:
-								selectMetrics !== "size"
+								selectMetrics !== "slice size"
 									? "datum.metrics < datum.mean_metrics"
 									: "datum.size < datum.mean_metrics",
 							value: "black",

--- a/frontend/src/report/line-chart/LineChartReport.svelte
+++ b/frontend/src/report/line-chart/LineChartReport.svelte
@@ -42,7 +42,7 @@
 					slices: r.slice,
 					models: r.model,
 					size: res[i].size,
-					...(selectMetrics !== "size" && {
+					...(selectMetrics !== "slice size" && {
 						metrics: res[i].metric.toFixed(2),
 					}),
 				})),

--- a/frontend/src/report/line-chart/vegaSpec-line.ts
+++ b/frontend/src/report/line-chart/vegaSpec-line.ts
@@ -43,7 +43,7 @@ export default function generateSpec(parameters, selectMetrics): VegaLiteSpec {
 			},
 			y: {
 				title: paramMap[y_encode].title,
-				field: selectMetrics !== "size" ? y_encode : "size",
+				field: selectMetrics !== "slice size" ? y_encode : "size",
 				type: paramMap[y_encode].type,
 				axis: {
 					labelFontSize: 14,
@@ -81,8 +81,8 @@ export default function generateSpec(parameters, selectMetrics): VegaLiteSpec {
 					size: 100,
 					tooltip: {
 						signal:
-							"{'slice_name': datum.slices,'size': datum.size, " +
-							(selectMetrics !== "size" ? selectMetrics : "accuracy") +
+							"{'slice_name': datum.slices,'slice_size': datum.size, " +
+							(selectMetrics !== "slice size" ? selectMetrics : "accuracy") +
 							": datum.metrics, 'model': datum.models}",
 					},
 				},
@@ -110,7 +110,7 @@ export default function generateSpec(parameters, selectMetrics): VegaLiteSpec {
 				},
 				encoding: {
 					text: {
-						field: selectMetrics !== "size" ? y_encode : "size",
+						field: selectMetrics !== "slice size" ? y_encode : "size",
 						type: paramMap[y_encode].type,
 					},
 					color: { value: "black" },

--- a/frontend/src/report/radar-chart/RadarChartReport.svelte
+++ b/frontend/src/report/radar-chart/RadarChartReport.svelte
@@ -92,7 +92,7 @@
 				table: chartEntries.map((r, i) => ({
 					key: r.key,
 					value:
-						r.key === "size" || fixedName === "size"
+						r.key === "slice size" || fixedName === "slice size"
 							? res[i].size
 							: res[i].metric.toFixed(2),
 					category: r.category,

--- a/frontend/src/report/report-page/encoding/MetricsEncodingDropdown.svelte
+++ b/frontend/src/report/report-page/encoding/MetricsEncodingDropdown.svelte
@@ -9,7 +9,7 @@
 			$reports[$report].metrics = [$metrics[0]];
 		}
 		// initial options & values
-		[...$metrics.values(), "size"].forEach((m, i) => {
+		[...$metrics.values(), "slice size"].forEach((m, i) => {
 			options[i] = { value: i, label: m };
 		});
 		value = options.find((o) => o.label === $reports[$report].metrics[0]).value;

--- a/frontend/src/report/report-page/encoding/MetricsEncodingMultiChoice.svelte
+++ b/frontend/src/report/report-page/encoding/MetricsEncodingMultiChoice.svelte
@@ -6,7 +6,7 @@
 	let value = [];
 
 	// initial options & values
-	[...$metrics.values(), "size"].forEach((m, i) => {
+	[...$metrics.values(), "slice size"].forEach((m, i) => {
 		options[i] = { value: i, label: m };
 	});
 	$reports[$report].metrics.forEach((m, i) => {

--- a/frontend/src/report/table-report/TableReportRow.svelte
+++ b/frontend/src/report/table-report/TableReportRow.svelte
@@ -23,7 +23,7 @@
 			<p>
 				{!r.metric ||
 				(parameters.zEncoding === "metrics" &&
-					currentReport.metrics[0] === "size")
+					currentReport.metrics[0] === "slice size")
 					? r.size
 					: r.metric.toFixed(2)}
 			</p>

--- a/zeno/util.py
+++ b/zeno/util.py
@@ -227,7 +227,7 @@ def read_functions(fns: Union[List[Callable], str]) -> List[Callable]:
 
 def is_notebook() -> bool:
     try:
-        from IPython import get_ipython
+        from IPython.core.getipython import get_ipython
 
         shell = get_ipython().__class__.__name__
         if shell == "ZMQInteractiveShell":


### PR DESCRIPTION
This PR changes the name of the metric "size" in the report to "slice size" in order to prevent any misunderstandings. 
Therefore, it will be necessary to update the affected reports, such as those that include the original "size" metric in their metric list.