### PR TITLE
fix: Make difference not absolute in qualitative comparison

### DIFF
--- a/zeno/backend.py
+++ b/zeno/backend.py
@@ -650,7 +650,9 @@ class ZenoBackend(object):
 
         # various metadata type difference
         if col_1.metadata_type == MetadataType.CONTINUOUS:
-            df.loc[:, "diff"] = df[str(col_1)].astype(float) - df[str(col_2)].astype(float)
+            df.loc[:, "diff"] = df[str(col_1)].astype(float) - df[str(col_2)].astype(
+                float
+            )
         else:
             df.loc[:, "diff"] = df[str(col_1)] != df[str(col_2)]
 

--- a/zeno/backend.py
+++ b/zeno/backend.py
@@ -650,9 +650,7 @@ class ZenoBackend(object):
 
         # various metadata type difference
         if col_1.metadata_type == MetadataType.CONTINUOUS:
-            df.loc[:, "diff"] = abs(
-                df[str(col_1)].astype(float) - df[str(col_2)].astype(float)
-            )
+            df.loc[:, "diff"] = df[str(col_1)].astype(float) - df[str(col_2)].astype(float)
         else:
             df.loc[:, "diff"] = df[str(col_1)] != df[str(col_2)]
 


### PR DESCRIPTION
This very simple PR removes the "abs" from the difference in the qualitative comparison tab so it shows the overall difference.

The reason why I think this design is better is because it allows users to easily view outputs where either
* system A is better than system B
* system B is better than system A

Whereas the previous design mixes together systems for both of these cases.