### PR TITLE
fix: line chart/heatmap number formatting

### DIFF
--- a/frontend/src/report/heatmap-chart/vegaSpec-heatmap.ts
+++ b/frontend/src/report/heatmap-chart/vegaSpec-heatmap.ts
@@ -102,6 +102,7 @@ export default function generateSpec(parameters, selectMetrics): VegaLiteSpec {
 					text: {
 						field: selectMetrics !== "slice size" ? "metrics" : "size",
 						type: "quantitative",
+						format: ".2f",
 					},
 					color: {
 						condition: {
@@ -113,7 +114,6 @@ export default function generateSpec(parameters, selectMetrics): VegaLiteSpec {
 						},
 						value: "white",
 					},
-					format: ".2f",
 				},
 			},
 		],

--- a/frontend/src/report/heatmap-chart/vegaSpec-heatmap_slice_vs_slice.ts
+++ b/frontend/src/report/heatmap-chart/vegaSpec-heatmap_slice_vs_slice.ts
@@ -90,6 +90,7 @@ export default function generateSliceVsSliceSpec(selectMetrics): VegaLiteSpec {
 					text: {
 						field: selectMetrics !== "slice size" ? "metrics" : "size",
 						type: "quantitative",
+						format: ".2f",
 					},
 					color: {
 						condition: {
@@ -100,7 +101,6 @@ export default function generateSliceVsSliceSpec(selectMetrics): VegaLiteSpec {
 							value: "black",
 						},
 						value: "white",
-						format: ".2f",
 					},
 				},
 			},

--- a/frontend/src/report/line-chart/vegaSpec-line.ts
+++ b/frontend/src/report/line-chart/vegaSpec-line.ts
@@ -112,9 +112,9 @@ export default function generateSpec(parameters, selectMetrics): VegaLiteSpec {
 					text: {
 						field: selectMetrics !== "slice size" ? y_encode : "size",
 						type: paramMap[y_encode].type,
+						format: paramMap[y_encode].type === "quantitative" ? ".2f" : "",
 					},
 					color: { value: "black" },
-					format: paramMap[y_encode].type === "quantitative" ? ".2f" : "",
 				},
 			},
 		],


### PR DESCRIPTION
PR https://github.com/zeno-ml/zeno/pull/869 fixed formatting for bar charts, but it had a bug that prevented proper display of line charts and heatmaps ("format" should be a property of "text" but it was one level too high in the hierarchy). This PR fixes this issue.