### PR TITLE
feat: add not option for string search

### DIFF
--- a/frontend/src/metadata/cells/metadata-cells/TextMetadataCell.svelte
+++ b/frontend/src/metadata/cells/metadata-cells/TextMetadataCell.svelte
@@ -2,15 +2,8 @@
 	import Button from "@smui/button";
 	import { TrailingIcon } from "@smui/chips";
 	import { Label } from "@smui/common";
-	import { tooltip } from "@svelte-plugins/tooltips";
-	import AutoComplete from "simple-svelte-autocomplete";
-	import {
-		ZenoService,
-		type FilterPredicate,
-		type ZenoColumn,
-	} from "../../../zenoservice";
-	import MatchWholeWordIcon from "./static/MatchWholeWordIcon.svelte";
-	import RegexIcon from "./static/RegexIcon.svelte";
+	import { type FilterPredicate, type ZenoColumn } from "../../../zenoservice";
+	import TextMetadataOptionBox from "./TextMetadataOptionBox.svelte";
 
 	export let col: ZenoColumn;
 	export let filterPredicates: FilterPredicate[];
@@ -19,27 +12,14 @@
 	let searchString = "";
 	let notOption = false;
 	let isRegex = false;
-	let regexValid = true;
 	let caseMatch = false;
 	let wholeWordMatch = false;
-	let refresh = 0;
-	let noResultsText = "No results";
-	let results = [];
 
 	let blur = function (ev) {
 		ev.target.blur();
 	};
-	$: {
-		regexValid = true;
-		if (isRegex) {
-			try {
-				new RegExp(searchString);
-			} catch (e) {
-				regexValid = false;
-			}
-		}
-	}
 
+	/** show the string search in chips and selection bar **/
 	function setSelection() {
 		if (!searchString) {
 			return;
@@ -69,131 +49,17 @@
 
 		searchString = "";
 	}
-
-	async function searchItems(input: string) {
-		if (isRegex) {
-			try {
-				new RegExp(input);
-				noResultsText = "No results";
-			} catch (e) {
-				noResultsText = "Invalid Regex!";
-				results = [];
-				return results;
-			}
-		}
-
-		try {
-			results = await ZenoService.filterStringMetadata({
-				column: col,
-				filterString: input,
-				isRegex: isRegex,
-				caseMatch: caseMatch,
-				wholeWordMatch: wholeWordMatch,
-			});
-			return results;
-		} catch (e) {
-			results = [];
-			return results;
-		}
-	}
-
-	function optionClick(e) {
-		if (e.currentTarget instanceof HTMLElement) {
-			let id = e.currentTarget.id;
-			if (id === "notOption") {
-				notOption = !notOption;
-			} else if (id === "caseMatch") {
-				caseMatch = !caseMatch;
-			} else if (id === "wholeWordMatch") {
-				wholeWordMatch = !wholeWordMatch;
-			} else {
-				if (isRegex) {
-					isRegex = false;
-					noResultsText = "No results";
-					regexValid = true;
-				} else {
-					isRegex = true;
-				}
-			}
-		}
-		refresh++;
-	}
 </script>
 
 <div class="container">
-	<div class="option-box" style:margin-right="10px">
-		<div
-			id="notOption"
-			class="search-option"
-			style:background={notOption ? "var(--P2)" : ""}
-			on:keydown={() => ({})}
-			on:click={optionClick}
-			use:tooltip={{
-				content: "Not",
-				theme: "zeno-tooltip",
-				autoPosition: true,
-			}}>
-			~
-		</div>
-	</div>
-	{#key refresh}
-		<AutoComplete
-			id="autoinput"
-			bind:text={searchString}
-			placeholder={"Search"}
-			{noResultsText}
-			hideArrow={true}
-			searchFunction={searchItems}
-			cleanUserText={false}
-			ignoreAccents={false}
-			localFiltering={false}
-			delay={200}>
-			<div slot="no-results" let:noResultsText>
-				<span style:color={regexValid ? "" : "red"}>{noResultsText}</span>
-			</div>
-		</AutoComplete>
-	{/key}
-	<div class="option-box">
-		<div
-			id="caseMatch"
-			class="search-option"
-			style:background={caseMatch ? "var(--P2)" : ""}
-			on:keydown={() => ({})}
-			on:click={optionClick}
-			use:tooltip={{
-				content: "Match Case",
-				theme: "zeno-tooltip",
-				autoPosition: true,
-			}}>
-			Aa
-		</div>
-		<div
-			id="wholeWordMatch"
-			class="search-option"
-			style:background={wholeWordMatch ? "var(--P2)" : ""}
-			on:keydown={() => ({})}
-			on:click={optionClick}
-			use:tooltip={{
-				content: "Match Whole Word",
-				theme: "zeno-tooltip",
-				autoPosition: true,
-			}}>
-			<svelte:component this={MatchWholeWordIcon} />
-		</div>
-		<div
-			id="typeSelection"
-			class="search-option"
-			style:background={isRegex ? "var(--P2)" : ""}
-			on:keydown={() => ({})}
-			on:click={optionClick}
-			use:tooltip={{
-				content: "Use Regular Expression",
-				theme: "zeno-tooltip",
-				autoPosition: true,
-			}}>
-			<svelte:component this={RegexIcon} />
-		</div>
-	</div>
+	<TextMetadataOptionBox
+		popup={false}
+		bind:searchString
+		bind:col
+		bind:notOption
+		bind:isRegex
+		bind:caseMatch
+		bind:wholeWordMatch />
 	<Button
 		style="margin-left: 10px; height: 32px"
 		variant="outlined"
@@ -230,29 +96,6 @@
 	.container {
 		display: flex;
 		align-items: center;
-	}
-	.option-box {
-		margin-left: 10px;
-		display: flex;
-		align-items: center;
-		border: 1px solid
-			var(--mdc-outlined-button-outline-color, rgba(0, 0, 0, 0.12));
-		border-radius: var(
-			--mdc-outlined-button-container-shape,
-			var(--mdc-shape-small, 4px)
-		);
-	}
-	.search-option {
-		display: flex;
-		align-items: center;
-		padding: 2px 3px;
-		padding-left: 6px;
-		padding-right: 6px;
-		height: 26px;
-		cursor: pointer;
-	}
-	.search-option:hover {
-		background: var(--Y1);
 	}
 	.chips {
 		display: flex;

--- a/frontend/src/metadata/cells/metadata-cells/TextMetadataCell.svelte
+++ b/frontend/src/metadata/cells/metadata-cells/TextMetadataCell.svelte
@@ -17,6 +17,7 @@
 	export let updatePredicates;
 
 	let searchString = "";
+	let notOption = false;
 	let isRegex = false;
 	let regexValid = true;
 	let caseMatch = false;
@@ -44,12 +45,23 @@
 			return;
 		}
 
+		// option string for slice detail when hovering over slice,
+		// use an array to keep the same order for case, wholeword, regex
+		let opString = [
+			notOption ? "not " : "",
+			"match",
+			caseMatch ? "(case)" : "",
+			wholeWordMatch ? "(wholeword)" : "",
+			isRegex ? "(regex)" : "",
+		];
+
 		filterPredicates.push({
 			column: col,
-			operation: isRegex ? "match (regex)" : "match",
+			operation: opString.filter((e) => e).join(" "),
 			value: searchString,
 			join: "",
 		});
+
 		if (filterPredicates.length > 1) {
 			filterPredicates[filterPredicates.length - 1].join = "|";
 		}
@@ -88,7 +100,9 @@
 	function optionClick(e) {
 		if (e.currentTarget instanceof HTMLElement) {
 			let id = e.currentTarget.id;
-			if (id === "caseMatch") {
+			if (id === "notOption") {
+				notOption = !notOption;
+			} else if (id === "caseMatch") {
 				caseMatch = !caseMatch;
 			} else if (id === "wholeWordMatch") {
 				wholeWordMatch = !wholeWordMatch;
@@ -107,6 +121,21 @@
 </script>
 
 <div class="container">
+	<div class="option-box" style:margin-right="10px">
+		<div
+			id="notOption"
+			class="search-option"
+			style:background={notOption ? "var(--P2)" : ""}
+			on:keydown={() => ({})}
+			on:click={optionClick}
+			use:tooltip={{
+				content: "Not",
+				theme: "zeno-tooltip",
+				autoPosition: true,
+			}}>
+			~
+		</div>
+	</div>
 	{#key refresh}
 		<AutoComplete
 			id="autoinput"
@@ -179,9 +208,8 @@
 	{#each filterPredicates as pred}
 		<div class="meta-chip">
 			<span>
-				{pred.operation === "match (regex)" ? "/" : ""}
-				{pred.value}
-				{pred.operation === "match (regex)" ? "/" : ""}
+				{pred.operation}
+				'{pred.value}'
 			</span>
 			<TrailingIcon
 				class="remove material-icons"
@@ -202,7 +230,6 @@
 	.container {
 		display: flex;
 		align-items: center;
-		margin-left: 5px;
 	}
 	.option-box {
 		margin-left: 10px;

--- a/frontend/src/metadata/cells/metadata-cells/TextMetadataOptionBox.svelte
+++ b/frontend/src/metadata/cells/metadata-cells/TextMetadataOptionBox.svelte
@@ -86,7 +86,7 @@
 	}
 </script>
 
-<div class="option-box" style:margin-right="10px">
+<div class="option-box" style:margin-right="5px">
 	<div
 		id="notOption"
 		class="search-option"
@@ -98,7 +98,7 @@
 			theme: "zeno-tooltip",
 			autoPosition: true,
 		}}>
-		~
+		NOT
 	</div>
 </div>
 {#key refresh}
@@ -163,7 +163,7 @@
 
 <style>
 	.option-box {
-		margin-left: 10px;
+		margin-left: 5px;
 		display: flex;
 		align-items: center;
 		border: 1px solid

--- a/frontend/src/metadata/cells/metadata-cells/TextMetadataOptionBox.svelte
+++ b/frontend/src/metadata/cells/metadata-cells/TextMetadataOptionBox.svelte
@@ -1,0 +1,188 @@
+<script lang="ts">
+	import { tooltip } from "@svelte-plugins/tooltips";
+	import AutoComplete from "simple-svelte-autocomplete";
+	import { ZenoService } from "../../../zenoservice";
+	import MatchWholeWordIcon from "./static/MatchWholeWordIcon.svelte";
+	import RegexIcon from "./static/RegexIcon.svelte";
+
+	export let col;
+	export let popup;
+	export let searchString;
+
+	// option box selection
+	export let notOption;
+	export let isRegex;
+	export let caseMatch;
+	export let wholeWordMatch;
+
+	// checking if regex is valid, such as not closing brackets (
+	let regexValid = true;
+	// forcing the autocomplete to rerender and show new search result after clicking the option
+	let refresh = 0;
+	let noResultsText = "No results";
+	let results = [];
+
+	/** Check if the current input is a legal regex format **/
+	$: {
+		regexValid = true;
+		if (isRegex) {
+			try {
+				new RegExp(searchString);
+			} catch (e) {
+				regexValid = false;
+			}
+		}
+	}
+
+	/** Show the search result when typing input in the search string box **/
+	async function searchItems(input: string) {
+		if (isRegex) {
+			try {
+				new RegExp(input);
+				noResultsText = "No results";
+			} catch (e) {
+				noResultsText = "Invalid Regex!";
+				results = [];
+				return results;
+			}
+		}
+
+		try {
+			results = await ZenoService.filterStringMetadata({
+				column: col,
+				filterString: input,
+				isRegex: isRegex,
+				caseMatch: caseMatch,
+				wholeWordMatch: wholeWordMatch,
+			});
+			return results;
+		} catch (e) {
+			results = [];
+			return results;
+		}
+	}
+
+	/** Control the parameters for option box **/
+	function optionClick(e) {
+		if (e.currentTarget instanceof HTMLElement) {
+			let id = e.currentTarget.id;
+			if (id === "notOption") {
+				notOption = !notOption;
+			} else if (id === "caseMatch") {
+				caseMatch = !caseMatch;
+			} else if (id === "wholeWordMatch") {
+				wholeWordMatch = !wholeWordMatch;
+			} else {
+				if (isRegex) {
+					isRegex = false;
+					noResultsText = "No results";
+					regexValid = true;
+				} else {
+					isRegex = true;
+				}
+			}
+		}
+		refresh++;
+	}
+</script>
+
+<div class="option-box" style:margin-right="10px">
+	<div
+		id="notOption"
+		class="search-option"
+		style:background={notOption ? "var(--P2)" : ""}
+		on:keydown={() => ({})}
+		on:click={optionClick}
+		use:tooltip={{
+			content: "Not",
+			theme: "zeno-tooltip",
+			autoPosition: true,
+		}}>
+		~
+	</div>
+</div>
+{#key refresh}
+	<AutoComplete
+		style={popup ? "margin-top: 1px;height: 35px" : ""}
+		id="autoinput"
+		bind:text={searchString}
+		placeholder={"Search"}
+		{noResultsText}
+		hideArrow={true}
+		searchFunction={searchItems}
+		cleanUserText={false}
+		ignoreAccents={false}
+		localFiltering={false}
+		delay={200}>
+		<div slot="no-results" let:noResultsText>
+			<span style:color={regexValid ? "" : "red"}>{noResultsText}</span>
+		</div>
+	</AutoComplete>
+{/key}
+<div class="option-box">
+	<div
+		id="caseMatch"
+		class="search-option"
+		style:background={caseMatch ? "var(--P2)" : ""}
+		on:keydown={() => ({})}
+		on:click={optionClick}
+		use:tooltip={{
+			content: "Match Case",
+			theme: "zeno-tooltip",
+			autoPosition: true,
+		}}>
+		Aa
+	</div>
+	<div
+		id="wholeWordMatch"
+		class="search-option"
+		style:background={wholeWordMatch ? "var(--P2)" : ""}
+		on:keydown={() => ({})}
+		on:click={optionClick}
+		use:tooltip={{
+			content: "Match Whole Word",
+			theme: "zeno-tooltip",
+			autoPosition: true,
+		}}>
+		<svelte:component this={MatchWholeWordIcon} />
+	</div>
+	<div
+		id="typeSelection"
+		class="search-option"
+		style:background={isRegex ? "var(--P2)" : ""}
+		on:keydown={() => ({})}
+		on:click={optionClick}
+		use:tooltip={{
+			content: "Use Regular Expression",
+			theme: "zeno-tooltip",
+			autoPosition: true,
+		}}>
+		<svelte:component this={RegexIcon} />
+	</div>
+</div>
+
+<style>
+	.option-box {
+		margin-left: 10px;
+		display: flex;
+		align-items: center;
+		border: 1px solid
+			var(--mdc-outlined-button-outline-color, rgba(0, 0, 0, 0.12));
+		border-radius: var(
+			--mdc-outlined-button-container-shape,
+			var(--mdc-shape-small, 4px)
+		);
+	}
+	.search-option {
+		display: flex;
+		align-items: center;
+		padding: 2px 3px;
+		padding-left: 6px;
+		padding-right: 6px;
+		height: 26px;
+		cursor: pointer;
+	}
+	.search-option:hover {
+		background: var(--Y1);
+	}
+</style>

--- a/frontend/src/metadata/cells/metadata-cells/TextMetadataOptionBox.svelte
+++ b/frontend/src/metadata/cells/metadata-cells/TextMetadataOptionBox.svelte
@@ -92,12 +92,7 @@
 		class="search-option"
 		style:background={notOption ? "var(--P2)" : ""}
 		on:keydown={() => ({})}
-		on:click={optionClick}
-		use:tooltip={{
-			content: "Not",
-			theme: "zeno-tooltip",
-			autoPosition: true,
-		}}>
+		on:click={optionClick}>
 		NOT
 	</div>
 </div>

--- a/frontend/src/metadata/chips/MetadataChip.svelte
+++ b/frontend/src/metadata/chips/MetadataChip.svelte
@@ -28,14 +28,13 @@
 			{/if}
 		{:else}
 			{chip[0].column.name}
-			{"=="}
+			{"("}
 			{chip
 				.map((c) => {
-					return c.operation === "match (regex)"
-						? "/" + c.value + "/"
-						: c.value;
+					return c.operation + " '" + c.value + "'";
 				})
 				.join(" | ")}
+			{")"}
 		{/if}
 	</span>
 	<TrailingIcon

--- a/frontend/src/metadata/popups/IdSearch.svelte
+++ b/frontend/src/metadata/popups/IdSearch.svelte
@@ -12,6 +12,7 @@
 	let isRegex = predicate.operation.includes("re");
 	let caseMatch = predicate.operation.includes("ca");
 	let wholeWordMatch = predicate.operation.includes("w");
+	let notOption = predicate.operation.includes("not");
 
 	// checking if regex is valid, such as not closing brackets (
 	let regexValid = true;
@@ -20,15 +21,6 @@
 
 	let noResultsText = "No results";
 	let searchResults = [];
-
-	// option string for slice detail when hovering over slice,
-	// use an array to keep the same order for case, wholeword, regex
-	let opString = [
-		"match",
-		caseMatch ? "(case)" : "",
-		wholeWordMatch ? "(wholeword)" : "",
-		isRegex ? "(regex)" : "",
-	];
 
 	$: {
 		regexValid = true;
@@ -71,30 +63,52 @@
 	function optionClick(e) {
 		if (e.currentTarget instanceof HTMLElement) {
 			let id = e.currentTarget.id;
-			if (id === "caseMatch") {
+			if (id === "notOption") {
+				notOption = !notOption;
+			} else if (id === "caseMatch") {
 				caseMatch = !caseMatch;
-				opString[1] = caseMatch ? "(case)" : "";
 			} else if (id === "wholeWordMatch") {
 				wholeWordMatch = !wholeWordMatch;
-				opString[2] = wholeWordMatch ? "(wholeword)" : "";
 			} else {
 				if (isRegex) {
 					isRegex = false;
 					noResultsText = "No results";
 					regexValid = true;
-					opString[3] = "";
 				} else {
 					isRegex = true;
-					opString[3] = "(regex)";
 				}
 			}
 		}
+		// option string for slice detail when hovering over slice,
+		// use an array to keep the same order for case, wholeword, regex
+		let opString = [
+			notOption ? "not" : "",
+			"match",
+			caseMatch ? "(case)" : "",
+			wholeWordMatch ? "(wholeword)" : "",
+			isRegex ? "(regex)" : "",
+		];
 		predicate.operation = opString.filter((e) => e).join(" ");
 		refresh++;
 	}
 </script>
 
 <div class="container">
+	<div class="option-box" style:margin-right="10px">
+		<div
+			id="notOption"
+			class="search-option"
+			style:background={notOption ? "var(--P2)" : ""}
+			on:keydown={() => ({})}
+			on:click={optionClick}
+			use:tooltip={{
+				content: "Not",
+				theme: "zeno-tooltip",
+				autoPosition: true,
+			}}>
+			~
+		</div>
+	</div>
 	{#key refresh}
 		<AutoComplete
 			style="height: 37px"
@@ -159,7 +173,6 @@
 	.container {
 		display: flex;
 		align-items: center;
-		margin-left: 5px;
 	}
 	.option-box {
 		margin-left: 10px;

--- a/frontend/src/metadata/popups/IdSearch.svelte
+++ b/frontend/src/metadata/popups/IdSearch.svelte
@@ -1,9 +1,5 @@
 <script lang="ts">
-	import AutoComplete from "simple-svelte-autocomplete";
-	import { tooltip } from "@svelte-plugins/tooltips";
-	import MatchWholeWordIcon from "../cells/metadata-cells/static/MatchWholeWordIcon.svelte";
-	import RegexIcon from "../cells/metadata-cells/static/RegexIcon.svelte";
-	import { ZenoService } from "../../zenoservice";
+	import TextMetadataOptionBox from "../cells/metadata-cells/TextMetadataOptionBox.svelte";
 
 	export let predicate;
 	export let col;
@@ -14,73 +10,8 @@
 	let wholeWordMatch = predicate.operation.includes("w");
 	let notOption = predicate.operation.includes("not");
 
-	// checking if regex is valid, such as not closing brackets (
-	let regexValid = true;
-	// forcing the autocomplete to rerender and show new search result after clicking the option
-	let refresh = 0;
-
-	let noResultsText = "No results";
-	let searchResults = [];
-
+	// updates predicate operation when options update
 	$: {
-		regexValid = true;
-		if (isRegex) {
-			try {
-				new RegExp(predicate.value);
-			} catch (e) {
-				regexValid = false;
-			}
-		}
-	}
-
-	async function searchItems(input: string) {
-		if (isRegex) {
-			try {
-				new RegExp(input);
-				noResultsText = "No results";
-			} catch (e) {
-				noResultsText = "Invalid Regex";
-				searchResults = [];
-				return searchResults;
-			}
-		}
-
-		try {
-			searchResults = await ZenoService.filterStringMetadata({
-				column: col,
-				filterString: input,
-				isRegex: isRegex,
-				caseMatch: caseMatch,
-				wholeWordMatch: wholeWordMatch,
-			});
-			return searchResults;
-		} catch (e) {
-			searchResults = [];
-			return searchResults;
-		}
-	}
-
-	function optionClick(e) {
-		if (e.currentTarget instanceof HTMLElement) {
-			let id = e.currentTarget.id;
-			if (id === "notOption") {
-				notOption = !notOption;
-			} else if (id === "caseMatch") {
-				caseMatch = !caseMatch;
-			} else if (id === "wholeWordMatch") {
-				wholeWordMatch = !wholeWordMatch;
-			} else {
-				if (isRegex) {
-					isRegex = false;
-					noResultsText = "No results";
-					regexValid = true;
-				} else {
-					isRegex = true;
-				}
-			}
-		}
-		// option string for slice detail when hovering over slice,
-		// use an array to keep the same order for case, wholeword, regex
 		let opString = [
 			notOption ? "not" : "",
 			"match",
@@ -89,112 +20,23 @@
 			isRegex ? "(regex)" : "",
 		];
 		predicate.operation = opString.filter((e) => e).join(" ");
-		refresh++;
 	}
 </script>
 
 <div class="container">
-	<div class="option-box" style:margin-right="10px">
-		<div
-			id="notOption"
-			class="search-option"
-			style:background={notOption ? "var(--P2)" : ""}
-			on:keydown={() => ({})}
-			on:click={optionClick}
-			use:tooltip={{
-				content: "Not",
-				theme: "zeno-tooltip",
-				autoPosition: true,
-			}}>
-			~
-		</div>
-	</div>
-	{#key refresh}
-		<AutoComplete
-			style="height: 37px"
-			id="autoinput"
-			bind:text={predicate.value}
-			{noResultsText}
-			hideArrow={true}
-			searchFunction={searchItems}
-			cleanUserText={false}
-			ignoreAccents={false}
-			localFiltering={false}
-			delay={200}>
-			<div slot="no-results" let:noResultsText>
-				<span style:color={regexValid ? "" : "red"}>{noResultsText}</span>
-			</div>
-		</AutoComplete>
-	{/key}
-	<div class="option-box">
-		<div
-			id="caseMatch"
-			class="search-option"
-			style:background={caseMatch ? "var(--P2)" : ""}
-			on:keydown={() => ({})}
-			on:click={optionClick}
-			use:tooltip={{
-				content: "Match Case",
-				theme: "zeno-tooltip",
-				autoPosition: true,
-			}}>
-			Aa
-		</div>
-		<div
-			id="wholeWordMatch"
-			class="search-option"
-			style:background={wholeWordMatch ? "var(--P2)" : ""}
-			on:keydown={() => ({})}
-			on:click={optionClick}
-			use:tooltip={{
-				content: "Match Whole Word",
-				theme: "zeno-tooltip",
-				autoPosition: true,
-			}}>
-			<svelte:component this={MatchWholeWordIcon} />
-		</div>
-		<div
-			id="typeSelection"
-			class="search-option"
-			style:background={isRegex ? "var(--P2)" : ""}
-			on:keydown={() => ({})}
-			on:click={optionClick}
-			use:tooltip={{
-				content: "Use Regular Expression",
-				theme: "zeno-tooltip",
-				autoPosition: true,
-			}}>
-			<svelte:component this={RegexIcon} />
-		</div>
-	</div>
+	<TextMetadataOptionBox
+		popup={true}
+		bind:searchString={predicate.value}
+		bind:col
+		bind:notOption
+		bind:isRegex
+		bind:caseMatch
+		bind:wholeWordMatch />
 </div>
 
 <style>
 	.container {
 		display: flex;
 		align-items: center;
-	}
-	.option-box {
-		margin-left: 10px;
-		display: flex;
-		align-items: center;
-		border: 1px solid
-			var(--mdc-outlined-button-outline-color, rgba(0, 0, 0, 0.12));
-		border-radius: var(
-			--mdc-outlined-button-container-shape,
-			var(--mdc-shape-small, 4px)
-		);
-	}
-	.search-option {
-		display: flex;
-		align-items: center;
-		padding: 2px 3px;
-		padding-left: 6px;
-		padding-right: 6px;
-		height: 30px;
-		cursor: pointer;
-	}
-	.search-option:hover {
-		background: var(--Y1);
 	}
 </style>

--- a/zeno/processing/filtering.py
+++ b/zeno/processing/filtering.py
@@ -31,6 +31,7 @@ def get_filter_string(filter: FilterPredicateGroup) -> str:
                 is_regex = "re" in f.operation
                 is_case = "ca" in f.operation
                 is_whole = "w" in f.operation
+                is_not = "not" in f.operation
 
                 if is_whole:
                     f.value = f"\\b{f.value}\\b" if is_regex else f'"{f.value}"'
@@ -42,7 +43,7 @@ def get_filter_string(filter: FilterPredicateGroup) -> str:
                     filt_string = f"{f.join} (`{f.column}`=={f.value})"
 
                 try:
-                    filt += filt_string
+                    filt += filt_string + "== False" if is_not else filt_string
                 except Exception as e:
                     print("Invalid Regex Error: ", e)
             else:


### PR DESCRIPTION
This PR introduces a new feature to enable string searches with a "not" option. When this option is used, the search results will exclusively include items that do not match the search criteria. Additionally, the update includes the extraction of the option box into a separate component, enhancing reusability and eliminating redundant code.