### PR TITLE
fix: remove folder cell options when in comparison tab

### DIFF
--- a/frontend/src/metadata/MetadataPanel.svelte
+++ b/frontend/src/metadata/MetadataPanel.svelte
@@ -378,7 +378,7 @@
 	</div>
 
 	{#each $folders as folder}
-		<FolderCell {folder} />
+		<FolderCell compare={$tab === "comparison"} {folder} />
 	{/each}
 
 	{#each [...$slices.values()].filter((s) => s.folder === "" && s.sliceName !== "All Instances") as s (s.sliceName)}

--- a/frontend/src/metadata/cells/FolderCell.svelte
+++ b/frontend/src/metadata/cells/FolderCell.svelte
@@ -16,6 +16,7 @@
 	import { clickOutside } from "../../util/clickOutside";
 
 	export let folder: string;
+	export let compare;
 
 	let expandFolder = false;
 	let dragOver = false;
@@ -122,23 +123,25 @@
 		<div style:margin-right="10px">
 			{sls.length} slice{sls.length === 1 ? "" : "s"}
 		</div>
-		<div class="inline" style:cursor="pointer">
-			<div style:width="36px">
-				{#if hovering}
-					<IconButton
-						size="button"
-						style="padding: 0px"
-						on:click={(e) => {
-							e.stopPropagation();
-							showOptions = !showOptions;
-						}}>
-						<Icon component={Svg} viewBox="0 0 24 24">
-							<path fill="black" d={mdiDotsHorizontal} />
-						</Icon>
-					</IconButton>
-				{/if}
+		{#if !compare}
+			<div class="inline" style:cursor="pointer">
+				<div style:width="36px">
+					{#if hovering}
+						<IconButton
+							size="button"
+							style="padding: 0px"
+							on:click={(e) => {
+								e.stopPropagation();
+								showOptions = !showOptions;
+							}}>
+							<Icon component={Svg} viewBox="0 0 24 24">
+								<path fill="black" d={mdiDotsHorizontal} />
+							</Icon>
+						</IconButton>
+					{/if}
+				</div>
 			</div>
-		</div>
+		{/if}
 	</div>
 </div>
 {#if expandFolder}


### PR DESCRIPTION
This PR removes folder options when it is in qualitative comparison tab.