### PR TITLE
fix: force the difference column being float type

### DIFF
--- a/zeno/util.py
+++ b/zeno/util.py
@@ -262,6 +262,9 @@ def generate_diff_cols(
 
     # various metadata type difference
     if diff_col_1.metadata_type == MetadataType.CONTINUOUS:
+        # force the column type being float
+        if "diff" in df.columns:
+            df["diff"] = df["diff"].astype(float)
         df.loc[:, "diff"] = df[str(diff_col_1)].astype(float) - df[
             str(diff_col_2)
         ].astype(float)


### PR DESCRIPTION
This PR addresses a bug that occurs when changing the comparison feature in the Qualitative comparison tab. Specifically, when transitioning from a boolean-type column to a continuous-type column, the difference column will display "True/False" instead of the actual difference in values.