### PR TITLE
feat: sort columns for better comparison and slice finder defaults

### DIFF
--- a/frontend/src/instance-views/ComparisonView.svelte
+++ b/frontend/src/instance-views/ComparisonView.svelte
@@ -20,7 +20,7 @@
 		status,
 		tagIds,
 	} from "../stores";
-	import { columnHash } from "../util/util";
+	import { columnHash, columnSort } from "../util/util";
 	import { ZenoColumnType, MetadataType } from "../zenoservice";
 	import type { ViewRenderFunction } from "./instance-views";
 	import ComparisonViewTableHeader from "./ComparisonViewTableHeader.svelte";
@@ -37,12 +37,15 @@
 	// decide which model column to show sort icon
 	let sortModel = "";
 
-	let options = $status.completeColumns.filter(
-		(c) =>
-			c.model === "" ||
-			c.model === $model ||
-			(sortModel === "" && c.model === $model)
-	);
+	let options = $status.completeColumns
+		.filter(
+			(c) =>
+				c.model === "" ||
+				c.model === $model ||
+				(sortModel === "" && c.model === $model)
+		)
+		.sort(columnSort);
+
 	let selectColumn = options[0];
 
 	let currentPage = 0;

--- a/frontend/src/metadata/popups/SliceFinderPopup.svelte
+++ b/frontend/src/metadata/popups/SliceFinderPopup.svelte
@@ -26,6 +26,7 @@
 	} from "../../zenoservice";
 	import SliceFinderCell from "../cells/SliceFinderCell.svelte";
 	import ChipsWrapper from "../ChipsWrapper.svelte";
+	import { columnSort } from "../../util/util";
 
 	let blur = function (ev) {
 		ev.target.blur();
@@ -47,18 +48,26 @@
 			d.metadataType !== MetadataType.DATETIME &&
 			completeColumns.includes(d)
 	);
-	let searchColumns = [searchColumnOptions[0]];
+	let postdistillColumnOptions = searchColumnOptions.filter(
+		(col) => col.columnType === ZenoColumnType.PREDISTILL
+	);
+	let searchColumns =
+		postdistillColumnOptions.length > 0
+			? postdistillColumnOptions
+			: [searchColumnOptions[0]];
 
 	// Column to use as the metric to compare slices.
-	let metricColumns = $status.completeColumns.filter((d) => {
-		return $tab !== "comparison"
-			? (d.metadataType === MetadataType.CONTINUOUS ||
-					d.metadataType === MetadataType.BOOLEAN) &&
-					completeColumns.includes(d)
-			: (d.columnType === ZenoColumnType.OUTPUT ||
-					d.columnType === ZenoColumnType.POSTDISTILL) &&
-					d.model === $model;
-	});
+	let metricColumns = $status.completeColumns
+		.filter((d) => {
+			return $tab !== "comparison"
+				? (d.metadataType === MetadataType.CONTINUOUS ||
+						d.metadataType === MetadataType.BOOLEAN) &&
+						completeColumns.includes(d)
+				: (d.columnType === ZenoColumnType.OUTPUT ||
+						d.columnType === ZenoColumnType.POSTDISTILL) &&
+						d.model === $model;
+		})
+		.sort(columnSort);
 	let metricColumn = metricColumns.length > 0 ? metricColumns[0] : null;
 	let compareColumn = undefined;
 	$: if (metricColumn && $tab === "comparison") {

--- a/frontend/src/util/util.ts
+++ b/frontend/src/util/util.ts
@@ -108,3 +108,36 @@ export function updateModelDependentSlices(name, mod, slis) {
 		}
 	});
 }
+
+function columnTypeOrder(colType: ZenoColumnType) {
+	switch (colType) {
+		case ZenoColumnType.POSTDISTILL:
+			return 0;
+		case ZenoColumnType.PREDISTILL:
+			return 1;
+		case ZenoColumnType.OUTPUT:
+			return 2;
+		case ZenoColumnType.METADATA:
+			return 3;
+		case ZenoColumnType.EMBEDDING:
+			return 4;
+	}
+}
+
+export function columnSort(col1: ZenoColumn, col2: ZenoColumn) {
+	if (columnTypeOrder(col1.columnType) > columnTypeOrder(col2.columnType)) {
+		return 1;
+	} else if (
+		columnTypeOrder(col1.columnType) < columnTypeOrder(col2.columnType)
+	) {
+		return -1;
+	}
+
+	if (col1.name < col2.name) {
+		return -1;
+	} else if (col1.name > col2.name) {
+		return 1;
+	} else {
+		return 0;
+	}
+}


### PR DESCRIPTION
The columns for comparison features and slice finder metrics are now sorted by type and name. The default slice finder search columns are now all predistill columns.

fixes #904 