### PR TITLE
fix: slice finder tootip width in comparison tab

### DIFF
--- a/frontend/src/metadata/MetadataPanel.svelte
+++ b/frontend/src/metadata/MetadataPanel.svelte
@@ -286,7 +286,7 @@
 							: "Find slices with the largest output differences between models",
 					position: "left",
 					theme: "zeno-tooltip",
-					maxWidth: $tab !== "comparison" ? "150" : "200",
+					maxWidth: 150,
 				}}>
 				<IconButton
 					on:click={() => {


### PR DESCRIPTION
This PR fix the max width of the slice-finder tooltip in the comparison tab to avoid hidden under the general header sidebar.