### PR TITLE
fix: related reports number logic

### DIFF
--- a/frontend/src/metadata/cells/SliceCell.svelte
+++ b/frontend/src/metadata/cells/SliceCell.svelte
@@ -239,7 +239,11 @@
 			? "s"
 			: ""}. Continue?</Content>
 	<Actions>
-		<Button on:click={() => (confirmDelete = false)}>
+		<Button
+			on:click={() => {
+				confirmDelete = false;
+				relatedReports = 0;
+			}}>
 			<Label>No</Label>
 		</Button>
 		<Button use={[InitialFocus]} on:click={() => removeSlice()}>


### PR DESCRIPTION
This PR addresses a minor logic issue regarding the display of the related report number in the popup when attempting to remove a slice.